### PR TITLE
Reuse one stored attachment across several notes

### DIFF
--- a/apps/desktop/src/main/database/queries/notes/index.ts
+++ b/apps/desktop/src/main/database/queries/notes/index.ts
@@ -12,10 +12,12 @@ export {
   bulkInsertNotes,
   clearNoteCache,
   getAllNoteIds,
+  getAllNoteRefRows,
   getAllCrdtNoteIds,
   getNotesModifiedAfter,
   type ListNotesOptions,
   type NoteCacheFileRow,
+  type NoteCacheRefRow,
   type NoteTreeCacheRow
 } from './note-crud'
 

--- a/apps/desktop/src/main/database/queries/notes/note-crud.ts
+++ b/apps/desktop/src/main/database/queries/notes/note-crud.ts
@@ -266,6 +266,28 @@ export function clearNoteCache(db: IndexDb): void {
   db.delete(noteCache).run()
 }
 
+export interface NoteCacheRefRow {
+  id: string
+  path: string
+  title: string
+}
+
+/**
+ * Every note in the index as `id`/`path`/`title`, journals included.
+ *
+ * Deliberately unfiltered, unlike {@link listNoteCacheFilesAfter} (which drops
+ * dated journal rows) and {@link listNotesFromCache} (which pages): the one
+ * caller walks the whole vault looking for notes that reference a given
+ * attachment, and a journal that embeds a PDF has to count as a reference or
+ * deleting the file would take the journal's embed with it.
+ */
+export function getAllNoteRefRows(db: IndexDb): NoteCacheRefRow[] {
+  return db
+    .select({ id: noteCache.id, path: noteCache.path, title: noteCache.title })
+    .from(noteCache)
+    .all()
+}
+
 export function getAllNoteIds(db: IndexDb): string[] {
   return db
     .select({ id: noteCache.id })

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -206,7 +206,7 @@ export interface MainIpcInvokeHandlers {
   "notes:create-folder": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
   "notes:create-property-definition": (...args: [{ name: string; type: "number" | "date" | "text" | "select" | "url" | "status" | "checkbox" | "multiselect"; options?: { value: string; color: string; default?: boolean | undefined; }[] | undefined; defaultValue?: unknown; color?: string | undefined; }]) => Awaited<Promise<{ success: true; definition: import("../../../../../packages/contracts/src/property-types").PropertyDefinition | undefined; } | { success: true; definition: { type: string; name: string; createdAt: string; color: string | null; clock: import("../../../../../packages/contracts/src/sync-api").VectorClock | null; syncedAt: string | null; options: string | null; defaultValue: string | null; }; }> | { success: false; error: string }>
   "notes:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "notes:delete-attachment": (...args: [{ noteId: string; filename: string; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>
+  "notes:delete-attachment": (...args: [{ noteId: string; filename: string; }]) => Awaited<Promise<{ deleted: boolean; referencedBy: string[]; success: true; }> | { success: false; error: string }>
   "notes:delete-folder": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
   "notes:delete-property-definition": (...args: [{ name: string; }]) => Awaited<Promise<{ success: boolean; }>>
   "notes:delete-version": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
@@ -230,12 +230,14 @@ export interface MainIpcInvokeHandlers {
   "notes:get-version": (...args: [string]) => Awaited<Promise<import("../vault/notes-versions").SnapshotDetail | null>>
   "notes:get-versions": (...args: [string]) => Awaited<Promise<import("../vault/notes-versions").SnapshotListItem[]>>
   "notes:import-files": (...args: [{ sourcePaths: string[]; targetFolder?: string | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").ImportFilesResult> | { success: false; error: string }>
+  "notes:insert-existing-attachment": (...args: [{ noteId: string; ownerNoteId: string; filename: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/notes-api").InsertExistingAttachmentResult>>
   "notes:large-file-close": (...args: [string]) => Awaited<Promise<void>>
   "notes:large-file-open": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/notes-api").LargeFileOpenResult>>
   "notes:large-file-read-lines": (...args: [{ sessionId: string; startLine: number; count: number; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/notes-api").LargeFileLinesResult | null>>
   "notes:large-file-search": (...args: [{ sessionId: string; query: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/notes-api").LargeFileSearchResult | null>>
   "notes:list": (...args: [{ folder?: string | undefined; tags?: string[] | undefined; sortBy?: "title" | "position" | "modified" | "created" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; fields?: "full" | "tree" | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").NoteListResponse>>
   "notes:list-attachments": (...args: [string]) => Awaited<Promise<import("../vault/attachments").AttachmentInfo[]>>
+  "notes:list-vault-attachments": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/notes-api").VaultAttachmentEntry[]>>
   "notes:move": (...args: [{ id: string; newFolder: string; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
   "notes:open-external": (...args: [string]) => Awaited<Promise<void>>
   "notes:preview-by-title": (...args: [string]) => Awaited<Promise<{ id: string; title: string; emoji: string | null; snippet: string | null; tags: { name: string; color: string; }[]; createdAt: string; } | null>>

--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -25,7 +25,8 @@ import {
   LargeFileReadLinesSchema,
   LargeFileSearchSchema,
   AttachmentActionSchema,
-  AttachmentRenameSchema
+  AttachmentRenameSchema,
+  InsertExistingAttachmentSchema
 } from '@memry/contracts/notes-api'
 import {
   resolveAttachment,
@@ -33,6 +34,10 @@ import {
   openAttachmentExternal
 } from '../vault/attachment-actions'
 import { renameAttachment } from '../vault/attachment-rename'
+import {
+  buildExistingAttachmentReference,
+  listVaultAttachments
+} from '../vault/attachment-references'
 import {
   openLargeFileSession,
   readLargeFileLines,
@@ -857,15 +862,32 @@ export function registerNotesHandlers(): void {
     })
   )
 
-  // notes:delete-attachment - Delete an attachment
+  // notes:delete-attachment - Detach an attachment from this note, deleting the
+  // bytes only when no other note still references them (#2077).
   registerCommand(
     NotesChannels.invoke.DELETE_ATTACHMENT,
     DeleteAttachmentSchema,
     async (input) => {
-      await deleteAttachment(input.noteId, input.filename)
-      return { success: true as const }
+      const outcome = await deleteAttachment(input.noteId, input.filename)
+      return { success: true as const, ...outcome }
     },
     'errors:attachment.deleteFailed'
+  )
+
+  // notes:list-vault-attachments - Everything the vault already stores, for the
+  // "insert existing attachment" picker (#2077).
+  ipcMain.handle(
+    NotesChannels.invoke.LIST_VAULT_ATTACHMENTS,
+    createHandler(() => listVaultAttachments())
+  )
+
+  // notes:insert-existing-attachment - Block props that point a second note at
+  // an attachment another note already stores. Nothing is copied or uploaded.
+  ipcMain.handle(
+    NotesChannels.invoke.INSERT_EXISTING_ATTACHMENT,
+    createValidatedHandler(InsertExistingAttachmentSchema, (input) =>
+      buildExistingAttachmentReference(input.noteId, input.ownerNoteId, input.filename)
+    )
   )
 
   // =========================================================================

--- a/apps/desktop/src/main/vault/attachment-actions.test.ts
+++ b/apps/desktop/src/main/vault/attachment-actions.test.ts
@@ -63,6 +63,34 @@ afterEach(() => {
   fs.rmSync(vaultPath, { recursive: true, force: true })
 })
 
+describe('shared attachment references (#2077)', () => {
+  it('resolves a ref into another note’s attachments folder', () => {
+    const absolute = writeAttachment('attachments/owner-note/k3f9x2-report.pdf')
+
+    const result = resolveAttachment(NOTE_ID, '../attachments/owner-note/k3f9x2-report.pdf')
+
+    expect(result.absolutePath).toBe(absolute)
+    expect(result.exists).toBe(true)
+  })
+
+  it('self-heals a shared ref after the owning note renames the file', () => {
+    // The owner renamed `k3f9x2-report.pdf` to `k3f9x2-invoice.pdf`; the
+    // borrowing note's body still names the old one. Self-heal matches on the
+    // nanoid prefix inside the owner's folder, so the embed keeps rendering
+    // instead of going blank.
+    writeAttachment('attachments/owner-note/k3f9x2-invoice.pdf')
+
+    const result = resolveAttachment(NOTE_ID, '../attachments/owner-note/k3f9x2-report.pdf')
+
+    expect(path.basename(result.absolutePath)).toBe('k3f9x2-invoice.pdf')
+    expect(result.exists).toBe(true)
+  })
+
+  it('still refuses a ref that climbs out of the vault', () => {
+    expect(() => resolveAttachment(NOTE_ID, '../../../../etc/passwd')).toThrow(NoteError)
+  })
+})
+
 describe('resolveAttachment', () => {
   it('resolves a note-relative ref to the on-disk path', () => {
     const absolute = writeAttachment('attachments/n1/k3f9x2-report.pdf')

--- a/apps/desktop/src/main/vault/attachment-reference-scan.test.ts
+++ b/apps/desktop/src/main/vault/attachment-reference-scan.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for attachment-reference-scan.ts (#2077).
+ *
+ * The invariant under test is the one that protects user data: removing an
+ * embed from one note must not delete a blob another note references.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  attachmentTargetFromAbsolutePath,
+  findNotesReferencingAttachment,
+  isAttachmentUnreferenced
+} from './attachment-reference-scan'
+
+const state = vi.hoisted(() => ({
+  vaultPath: '',
+  rows: [] as { id: string; path: string; title: string }[],
+  throwOnRows: false
+}))
+
+vi.mock('./notes-io', () => ({
+  getVaultRoot: () => {
+    if (!state.vaultPath) throw new Error('No vault is open')
+    return state.vaultPath
+  }
+}))
+
+vi.mock('../database', () => ({
+  getIndexDatabase: () => ({})
+}))
+
+vi.mock('@main/database/queries/notes', () => ({
+  getAllNoteRefRows: () => {
+    if (state.throwOnRows) throw new Error('index unavailable')
+    return state.rows
+  }
+}))
+
+function writeNote(relativePath: string, body: string): void {
+  const absolute = path.join(state.vaultPath, relativePath)
+  fs.mkdirSync(path.dirname(absolute), { recursive: true })
+  fs.writeFileSync(absolute, body)
+}
+
+describe('attachmentTargetFromAbsolutePath', () => {
+  it('reads the owner note and filename out of a vault attachment path', () => {
+    expect(
+      attachmentTargetFromAbsolutePath('/vault', '/vault/attachments/note-a/k3f9x2-report.pdf')
+    ).toEqual({ ownerNoteId: 'note-a', filename: 'k3f9x2-report.pdf' })
+  })
+
+  it('rejects anything outside the attachments tree', () => {
+    expect(attachmentTargetFromAbsolutePath('/vault', '/vault/notes/Foo.md')).toBeNull()
+    expect(attachmentTargetFromAbsolutePath('/vault', '/elsewhere/attachments/a/b.pdf')).toBeNull()
+    expect(
+      attachmentTargetFromAbsolutePath('/vault', '/vault/attachments/note-a/nested/b.pdf')
+    ).toBeNull()
+  })
+})
+
+describe('findNotesReferencingAttachment', () => {
+  beforeEach(() => {
+    state.vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'attachment-ref-scan-'))
+    state.rows = []
+    state.throwOnRows = false
+  })
+
+  afterEach(() => {
+    fs.rmSync(state.vaultPath, { recursive: true, force: true })
+    state.vaultPath = ''
+  })
+
+  const target = { ownerNoteId: 'note-a', filename: 'k3f9x2-report.pdf' }
+
+  it('finds a note-relative shared ref written by desktop', () => {
+    writeNote('notes/B.md', '<!-- file:{"url":"../attachments/note-a/k3f9x2-report.pdf"} -->')
+    state.rows = [{ id: 'note-b', path: 'notes/B.md', title: 'B' }]
+
+    expect(findNotesReferencingAttachment(target)).toEqual({
+      referencedBy: ['note-b'],
+      complete: true
+    })
+  })
+
+  it('finds a mobile root-relative ref and a legacy absolute one', () => {
+    writeNote('notes/B.md', '![x](attachments/note-a/k3f9x2-report.pdf)')
+    writeNote(
+      'notes/C.md',
+      '![x](memry-file://local/Users/someone/OtherVault/attachments/note-a/k3f9x2-report.pdf)'
+    )
+    state.rows = [
+      { id: 'note-b', path: 'notes/B.md', title: 'B' },
+      { id: 'note-c', path: 'notes/C.md', title: 'C' }
+    ]
+
+    expect(findNotesReferencingAttachment(target).referencedBy).toEqual(['note-b', 'note-c'])
+  })
+
+  it('finds a reference from a journal, which the paged note scans skip', () => {
+    writeNote('journals/2026-09-11.md', '![x](../attachments/note-a/k3f9x2-report.pdf)')
+    state.rows = [{ id: 'journal-1', path: 'journals/2026-09-11.md', title: '2026-09-11' }]
+
+    expect(findNotesReferencingAttachment(target).referencedBy).toEqual(['journal-1'])
+  })
+
+  it('ignores a different file in the same folder and the same name elsewhere', () => {
+    writeNote(
+      'notes/B.md',
+      [
+        '![x](../attachments/note-a/aaaaaa-other.pdf)',
+        '![y](../attachments/note-z/k3f9x2-report.pdf)'
+      ].join('\n')
+    )
+    state.rows = [{ id: 'note-b', path: 'notes/B.md', title: 'B' }]
+
+    expect(findNotesReferencingAttachment(target).referencedBy).toEqual([])
+  })
+
+  it('excludes the note that is asking', () => {
+    writeNote('notes/A.md', '![x](../attachments/note-a/k3f9x2-report.pdf)')
+    state.rows = [{ id: 'note-a', path: 'notes/A.md', title: 'A' }]
+
+    expect(
+      findNotesReferencingAttachment(target, { excludeNoteId: 'note-a' }).referencedBy
+    ).toEqual([])
+  })
+
+  it('skips index rows whose file is gone rather than failing the scan', () => {
+    state.rows = [{ id: 'ghost', path: 'notes/Gone.md', title: 'Gone' }]
+
+    expect(findNotesReferencingAttachment(target)).toEqual({ referencedBy: [], complete: true })
+  })
+
+  it('reports an incomplete scan when the notes cannot be enumerated', () => {
+    state.throwOnRows = true
+
+    expect(findNotesReferencingAttachment(target)).toEqual({ referencedBy: [], complete: false })
+  })
+})
+
+describe('isAttachmentUnreferenced', () => {
+  beforeEach(() => {
+    state.vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'attachment-ref-scan-'))
+    state.rows = []
+    state.throwOnRows = false
+  })
+
+  afterEach(() => {
+    fs.rmSync(state.vaultPath, { recursive: true, force: true })
+    state.vaultPath = ''
+  })
+
+  it('is false for a shared blob and false again when the scan cannot prove it', () => {
+    writeNote('notes/B.md', '![x](../attachments/note-a/k3f9x2-report.pdf)')
+    state.rows = [{ id: 'note-b', path: 'notes/B.md', title: 'B' }]
+    expect(isAttachmentUnreferenced({ ownerNoteId: 'note-a', filename: 'k3f9x2-report.pdf' })).toBe(
+      false
+    )
+
+    state.throwOnRows = true
+    expect(isAttachmentUnreferenced({ ownerNoteId: 'note-a', filename: 'k3f9x2-report.pdf' })).toBe(
+      false
+    )
+  })
+
+  it('is true only when nothing references the blob', () => {
+    state.rows = []
+    expect(isAttachmentUnreferenced({ ownerNoteId: 'note-a', filename: 'k3f9x2-report.pdf' })).toBe(
+      true
+    )
+  })
+})

--- a/apps/desktop/src/main/vault/attachment-reference-scan.ts
+++ b/apps/desktop/src/main/vault/attachment-reference-scan.ts
@@ -1,0 +1,115 @@
+/**
+ * Who still points at an attachment (#2077).
+ *
+ * An attachment's bytes live at `attachments/<ownerNoteId>/<storedFilename>`
+ * and never move. A note references them through its block `url`, in one of the
+ * shapes `attachment-actions.ts` documents: note-relative
+ * (`../attachments/<owner>/<file>`), mobile root-relative
+ * (`attachments/<owner>/<file>`) or legacy absolute
+ * (`memry-file://local/…/attachments/<owner>/<file>`). Every one of them
+ * contains the literal `attachments/<owner>/<file>` run, which is what makes a
+ * substring scan of the note bodies a complete answer rather than a heuristic.
+ *
+ * This exists so that deleting an attachment cannot take a second note's embed
+ * with it: a shared reference is the whole point of "insert existing
+ * attachment", and the delete path is the only thing in the app that removes a
+ * blob (note deletion deliberately leaves the folder alone).
+ *
+ * It stays free of any import from `attachments.ts` on purpose — that module
+ * calls into this one, and the reverse edge would be a cycle.
+ *
+ * @module vault/attachment-reference-scan
+ */
+
+import { readFileSync } from 'fs'
+import path from 'path'
+import { getAllNoteRefRows } from '@main/database/queries/notes'
+import { getIndexDatabase } from '../database'
+import { createLogger } from '../lib/logger'
+import { getVaultRoot } from './notes-io'
+
+const logger = createLogger('AttachmentReferenceScan')
+
+/** The stable identity of a stored blob: the folder that owns it plus its name. */
+export interface AttachmentTarget {
+  ownerNoteId: string
+  filename: string
+}
+
+export interface FindReferencesOptions {
+  /** A note whose own references do not count — the one asking to delete. */
+  excludeNoteId?: string
+}
+
+/**
+ * The vault-relative `attachments/<owner>/<file>` target an absolute path names,
+ * or null when the path is not inside the vault's attachments tree.
+ */
+export function attachmentTargetFromAbsolutePath(
+  vaultPath: string,
+  absolutePath: string
+): AttachmentTarget | null {
+  const relative = path.relative(path.resolve(vaultPath), path.resolve(absolutePath))
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null
+  const segments = relative.split(/[/\\]/).filter(Boolean)
+  if (segments.length !== 3 || segments[0] !== 'attachments') return null
+  return { ownerNoteId: segments[1], filename: segments[2] }
+}
+
+/** What a scan found, and whether it managed to look at everything. */
+export interface AttachmentReferenceScan {
+  /** Note ids whose body names the target, `excludeNoteId` aside. */
+  referencedBy: string[]
+  /**
+   * False when the scan could not read the index or the vault root. The caller
+   * must then behave as if the file were shared: "unknown" may never license a
+   * deletion.
+   */
+  complete: boolean
+}
+
+/**
+ * Which notes still reference `target`.
+ *
+ * A note row whose file is missing is skipped — a file that is not there cannot
+ * be holding a reference — but a failure to enumerate the notes at all clears
+ * {@link AttachmentReferenceScan.complete} instead of being reported as "no
+ * references".
+ */
+export function findNotesReferencingAttachment(
+  target: AttachmentTarget,
+  options?: FindReferencesOptions
+): AttachmentReferenceScan {
+  const needle = `attachments/${target.ownerNoteId}/${target.filename}`
+  let vaultPath: string
+  let rows: { id: string; path: string }[]
+  try {
+    vaultPath = getVaultRoot()
+    rows = getAllNoteRefRows(getIndexDatabase())
+  } catch (error) {
+    logger.warn('Reference scan could not read the index; treating the file as shared', { error })
+    return { referencedBy: [], complete: false }
+  }
+
+  const referencedBy: string[] = []
+  for (const row of rows) {
+    if (row.id === options?.excludeNoteId) continue
+    let body: string
+    try {
+      body = readFileSync(path.join(vaultPath, row.path), 'utf-8')
+    } catch {
+      continue
+    }
+    if (body.includes(needle)) referencedBy.push(row.id)
+  }
+  return { referencedBy, complete: true }
+}
+
+/** True when nothing else references the target and the scan could prove it. */
+export function isAttachmentUnreferenced(
+  target: AttachmentTarget,
+  options?: FindReferencesOptions
+): boolean {
+  const scan = findNotesReferencingAttachment(target, options)
+  return scan.complete && scan.referencedBy.length === 0
+}

--- a/apps/desktop/src/main/vault/attachment-references.test.ts
+++ b/apps/desktop/src/main/vault/attachment-references.test.ts
@@ -16,7 +16,8 @@ import {
 
 const state = vi.hoisted(() => ({
   vaultPath: '',
-  rows: [] as { id: string; path: string; title: string }[]
+  rows: [] as { id: string; path: string; title: string }[],
+  throwOnRows: false
 }))
 
 vi.mock('./notes-io', () => ({
@@ -35,7 +36,10 @@ vi.mock('../database', () => ({
 }))
 
 vi.mock('@main/database/queries/notes', () => ({
-  getAllNoteRefRows: () => state.rows,
+  getAllNoteRefRows: () => {
+    if (state.throwOnRows) throw new Error('index unavailable')
+    return state.rows
+  },
   getNoteCacheById: (_db: unknown, id: string) => state.rows.find((row) => row.id === id)
 }))
 
@@ -59,6 +63,7 @@ describe('attachment references', () => {
       { id: 'note-a', path: 'notes/A.md', title: 'Invoices' },
       { id: 'note-b', path: 'notes/archive/2026/B.md', title: 'Archive' }
     ]
+    state.throwOnRows = false
   })
 
   afterEach(() => {
@@ -99,6 +104,38 @@ describe('attachment references', () => {
 
     it('is empty when the vault has no attachments folder', () => {
       expect(listVaultAttachments()).toEqual([])
+    })
+
+    it('still lists the files when the note titles cannot be read', () => {
+      writeAttachment('note-a', 'k3f9x2-report.pdf')
+      state.throwOnRows = true
+
+      expect(listVaultAttachments()).toEqual([
+        expect.objectContaining({ ownerNoteId: 'note-a', ownerNoteTitle: null })
+      ])
+    })
+
+    it('skips an owner folder it cannot read and keeps walking the rest', () => {
+      writeAttachment('note-a', 'k3f9x2-report.pdf')
+      writeAttachment('note-b', 'bbbbbb-secret.pdf')
+      const locked = path.join(state.vaultPath, 'attachments', 'note-b')
+      fs.chmodSync(locked, 0o000)
+      try {
+        expect(listVaultAttachments().map((e) => e.filename)).toEqual(['k3f9x2-report.pdf'])
+      } finally {
+        fs.chmodSync(locked, 0o700)
+      }
+    })
+
+    it('is empty rather than partial when the attachments folder itself is unreadable', () => {
+      writeAttachment('note-a', 'k3f9x2-report.pdf')
+      const root = path.join(state.vaultPath, 'attachments')
+      fs.chmodSync(root, 0o000)
+      try {
+        expect(listVaultAttachments()).toEqual([])
+      } finally {
+        fs.chmodSync(root, 0o700)
+      }
     })
   })
 

--- a/apps/desktop/src/main/vault/attachment-references.test.ts
+++ b/apps/desktop/src/main/vault/attachment-references.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for attachment-references.ts (#2077) — the "insert existing attachment"
+ * seam. The ref it hands back is the whole relationship, so what matters is
+ * that it names the OWNING note's folder from the RECEIVING note's directory.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  buildExistingAttachmentReference,
+  displayNameForStoredFilename,
+  listVaultAttachments
+} from './attachment-references'
+
+const state = vi.hoisted(() => ({
+  vaultPath: '',
+  rows: [] as { id: string; path: string; title: string }[]
+}))
+
+vi.mock('./notes-io', () => ({
+  getVaultRoot: () => {
+    if (!state.vaultPath) throw new Error('No vault is open')
+    return state.vaultPath
+  }
+}))
+
+vi.mock('./index', () => ({
+  getStatus: () => ({ path: state.vaultPath, isOpen: true })
+}))
+
+vi.mock('../database', () => ({
+  getIndexDatabase: () => ({})
+}))
+
+vi.mock('@main/database/queries/notes', () => ({
+  getAllNoteRefRows: () => state.rows,
+  getNoteCacheById: (_db: unknown, id: string) => state.rows.find((row) => row.id === id)
+}))
+
+function writeAttachment(ownerNoteId: string, filename: string, body = 'bytes'): void {
+  const dir = path.join(state.vaultPath, 'attachments', ownerNoteId)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, filename), body)
+}
+
+describe('displayNameForStoredFilename', () => {
+  it('drops the nanoid prefix and leaves anything else alone', () => {
+    expect(displayNameForStoredFilename('k3f9x2-report.pdf')).toBe('report.pdf')
+    expect(displayNameForStoredFilename('report.pdf')).toBe('report.pdf')
+  })
+})
+
+describe('attachment references', () => {
+  beforeEach(() => {
+    state.vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'attachment-references-'))
+    state.rows = [
+      { id: 'note-a', path: 'notes/A.md', title: 'Invoices' },
+      { id: 'note-b', path: 'notes/archive/2026/B.md', title: 'Archive' }
+    ]
+  })
+
+  afterEach(() => {
+    fs.rmSync(state.vaultPath, { recursive: true, force: true })
+    state.vaultPath = ''
+  })
+
+  describe('listVaultAttachments', () => {
+    it('lists attachments from every note folder with the owning note title', () => {
+      writeAttachment('note-a', 'k3f9x2-report.pdf')
+      writeAttachment('note-b', 'aaaaaa-photo.png')
+
+      const entries = listVaultAttachments()
+
+      expect(entries.map((e) => [e.ownerNoteId, e.displayName, e.ownerNoteTitle, e.type])).toEqual(
+        expect.arrayContaining([
+          ['note-a', 'report.pdf', 'Invoices', 'file'],
+          ['note-b', 'photo.png', 'Archive', 'image']
+        ])
+      )
+    })
+
+    it('keeps a folder whose note is no longer indexed, with no title', () => {
+      writeAttachment('orphan-note', 'k3f9x2-report.pdf')
+
+      expect(listVaultAttachments()).toEqual([
+        expect.objectContaining({ ownerNoteId: 'orphan-note', ownerNoteTitle: null })
+      ])
+    })
+
+    it('skips dotfiles and extensions no block can render', () => {
+      writeAttachment('note-a', '.DS_Store')
+      writeAttachment('note-a', 'k3f9x2-notes.sqlite')
+      writeAttachment('note-a', 'k3f9x2-report.pdf')
+
+      expect(listVaultAttachments().map((e) => e.filename)).toEqual(['k3f9x2-report.pdf'])
+    })
+
+    it('is empty when the vault has no attachments folder', () => {
+      expect(listVaultAttachments()).toEqual([])
+    })
+  })
+
+  describe('buildExistingAttachmentReference', () => {
+    it('points a note in a deeper folder at the owning note’s stored file', () => {
+      writeAttachment('note-a', 'k3f9x2-report.pdf')
+
+      const result = buildExistingAttachmentReference('note-b', 'note-a', 'k3f9x2-report.pdf')
+
+      expect(result).toEqual({
+        url: '../../../attachments/note-a/k3f9x2-report.pdf',
+        name: 'report.pdf',
+        filename: 'k3f9x2-report.pdf',
+        ownerNoteId: 'note-a',
+        size: 5,
+        mimeType: 'application/pdf',
+        type: 'file'
+      })
+    })
+
+    it('copies nothing: the bytes stay in the owning note’s folder only', () => {
+      writeAttachment('note-a', 'k3f9x2-report.pdf')
+
+      buildExistingAttachmentReference('note-b', 'note-a', 'k3f9x2-report.pdf')
+
+      expect(fs.existsSync(path.join(state.vaultPath, 'attachments', 'note-b'))).toBe(false)
+      expect(fs.readdirSync(path.join(state.vaultPath, 'attachments', 'note-a'))).toEqual([
+        'k3f9x2-report.pdf'
+      ])
+    })
+
+    it('is an ordinary local ref when a note references its own attachment', () => {
+      writeAttachment('note-a', 'k3f9x2-report.pdf')
+
+      expect(buildExistingAttachmentReference('note-a', 'note-a', 'k3f9x2-report.pdf').url).toBe(
+        '../attachments/note-a/k3f9x2-report.pdf'
+      )
+    })
+
+    it('refuses a traversal in either identifier', () => {
+      writeAttachment('note-a', 'k3f9x2-report.pdf')
+
+      expect(() => buildExistingAttachmentReference('note-b', '../..', 'x.pdf')).toThrow()
+      expect(() =>
+        buildExistingAttachmentReference('note-b', 'note-a', '../note-a/k3f9x2-report.pdf')
+      ).toThrow()
+    })
+
+    it('refuses a file that is not on disk, and an unknown receiving note', () => {
+      expect(() =>
+        buildExistingAttachmentReference('note-b', 'note-a', 'k3f9x2-report.pdf')
+      ).toThrow()
+
+      writeAttachment('note-a', 'k3f9x2-report.pdf')
+      expect(() =>
+        buildExistingAttachmentReference('missing-note', 'note-a', 'k3f9x2-report.pdf')
+      ).toThrow()
+    })
+  })
+})

--- a/apps/desktop/src/main/vault/attachment-references.ts
+++ b/apps/desktop/src/main/vault/attachment-references.ts
@@ -1,0 +1,187 @@
+/**
+ * Insert an attachment a note already has into a second note (#2077).
+ *
+ * The relationship is not a new record: it is the ref itself. An attachment's
+ * bytes live at `attachments/<ownerNoteId>/<storedFilename>` and stay there for
+ * life, so `(ownerNoteId, storedFilename)` is already a stable, vault-wide
+ * identity — the same one the existing note-relative ref encodes. A second note
+ * embeds the same blob by writing that same target relative to its own folder,
+ * which means every path that already understands attachment refs (resolve,
+ * self-heal, cross-device remap, move rewriting, the markdown serializer)
+ * understands a shared one with no change, and every older vault keeps reading
+ * exactly as before.
+ *
+ * What that costs is paid elsewhere: `attachment-reference-scan.ts` is how the
+ * delete path learns that the bytes are not its own to remove.
+ *
+ * Two things this deliberately does not do:
+ *
+ *  - It never copies bytes. Inserting an existing attachment writes a ref and
+ *    nothing else, so there is no second upload, no second blob and no second
+ *    manifest; the owning note's sync already carries the file to every device,
+ *    and the borrowing note's ref resolves against it once it lands.
+ *  - It never de-duplicates what is already there. Two notes that each uploaded
+ *    the same PDF keep their own copies — collapsing them would rewrite bodies
+ *    the user did not ask us to touch and would make a delete in one note
+ *    reach into another.
+ *
+ * @module vault/attachment-references
+ */
+
+import { existsSync, readdirSync, statSync } from 'fs'
+import path from 'path'
+import type {
+  VaultAttachmentEntry,
+  InsertExistingAttachmentResult
+} from '@memry/contracts/notes-api'
+import { getAllNoteRefRows, getNoteCacheById } from '@main/database/queries/notes'
+import { getIndexDatabase } from '../database'
+import { NoteError, NoteErrorCode } from '../lib/errors'
+import { createLogger } from '../lib/logger'
+import {
+  getAttachmentRef,
+  getFileType,
+  getMimeType,
+  getNoteAttachmentsDir,
+  isAllowedFileType
+} from './attachments'
+import { getVaultRoot } from './notes-io'
+
+const logger = createLogger('AttachmentReferences')
+
+/** The `{6-char nanoid}-` prefix `generateUniqueFilename` puts on every file. */
+const STORED_PREFIX_RE = /^[0-9a-z]{6}-/
+
+/**
+ * The name to show for a stored file: the nanoid prefix off, nothing else.
+ *
+ * The block prop the uploading note carries is the true original name, but it
+ * lives in that note's body rather than on disk, and reading every note to
+ * recover it would make opening a picker cost a vault scan. Dropping the prefix
+ * gets back the sanitized original, which is what the user typed modulo spaces.
+ */
+export function displayNameForStoredFilename(filename: string): string {
+  return STORED_PREFIX_RE.test(filename) ? filename.slice(7) : filename
+}
+
+/**
+ * Every attachment in the vault, newest first, with the note that stores it.
+ *
+ * Walks `attachments/` rather than any table because the folder is the source
+ * of truth for what exists on this device — the same reason
+ * `listNoteAttachments` does. Folders whose note id is no longer in the index
+ * are still listed: the bytes are real and a user may well want them back in a
+ * note, they just have no title to show.
+ */
+export function listVaultAttachments(): VaultAttachmentEntry[] {
+  const vaultPath = getVaultRoot()
+  const root = path.join(vaultPath, 'attachments')
+  if (!existsSync(root)) return []
+
+  const titles = new Map<string, string>()
+  try {
+    for (const row of getAllNoteRefRows(getIndexDatabase())) titles.set(row.id, row.title)
+  } catch (error) {
+    logger.warn('Could not read note titles for the attachment picker', { error })
+  }
+
+  const entries: VaultAttachmentEntry[] = []
+  let ownerDirs: string[]
+  try {
+    ownerDirs = readdirSync(root, { withFileTypes: true })
+      .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+      .map((d) => d.name)
+  } catch (error) {
+    logger.warn('Could not read the attachments folder', { error })
+    return []
+  }
+
+  for (const ownerNoteId of ownerDirs) {
+    const dir = path.join(root, ownerNoteId)
+    let files: string[]
+    try {
+      files = readdirSync(dir, { withFileTypes: true })
+        .filter((d) => d.isFile() && !d.name.startsWith('.'))
+        .map((d) => d.name)
+    } catch {
+      continue
+    }
+    for (const filename of files) {
+      // Extension-gated the same way uploads are: a folder can hold whatever an
+      // importer put there, and the picker only offers what a block can render.
+      if (!isAllowedFileType(filename)) continue
+      let size: number
+      let modifiedAt: string
+      try {
+        const stats = statSync(path.join(dir, filename))
+        size = stats.size
+        modifiedAt = stats.mtime.toISOString()
+      } catch {
+        continue
+      }
+      entries.push({
+        ownerNoteId,
+        ownerNoteTitle: titles.get(ownerNoteId) ?? null,
+        filename,
+        displayName: displayNameForStoredFilename(filename),
+        size,
+        mimeType: getMimeType(filename),
+        type: getFileType(filename),
+        modifiedAt
+      })
+    }
+  }
+
+  entries.sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt))
+  return entries
+}
+
+/**
+ * The block props `noteId` should use to embed an attachment stored under
+ * `ownerNoteId` — including when the two are the same note, which is simply an
+ * ordinary local ref.
+ *
+ * Validated rather than trusted: both ids have to be plain path segments and the
+ * file has to exist, so a crafted `ownerNoteId` can never make a note reference
+ * something outside `attachments/`.
+ */
+export function buildExistingAttachmentReference(
+  noteId: string,
+  ownerNoteId: string,
+  filename: string
+): InsertExistingAttachmentResult {
+  if (!isPlainSegment(ownerNoteId) || !isPlainSegment(filename)) {
+    throw new NoteError('Invalid attachment reference', NoteErrorCode.INVALID_PATH, noteId)
+  }
+
+  const vaultPath = getVaultRoot()
+  const diskPath = path.join(getNoteAttachmentsDir(vaultPath, ownerNoteId), filename)
+  if (!existsSync(diskPath)) {
+    throw new NoteError('Attachment file not found on disk', NoteErrorCode.NOT_FOUND, noteId)
+  }
+
+  const notePath = getNoteCacheById(getIndexDatabase(), noteId)?.path
+  if (!notePath) {
+    throw new NoteError(`Note not found: ${noteId}`, NoteErrorCode.NOT_FOUND, noteId)
+  }
+
+  return {
+    url: getAttachmentRef(vaultPath, ownerNoteId, filename, notePath),
+    name: displayNameForStoredFilename(filename),
+    filename,
+    ownerNoteId,
+    size: statSync(diskPath).size,
+    mimeType: getMimeType(filename),
+    type: getFileType(filename)
+  }
+}
+
+function isPlainSegment(value: string): boolean {
+  return (
+    value.length > 0 &&
+    !value.includes('/') &&
+    !value.includes('\\') &&
+    value !== '.' &&
+    value !== '..'
+  )
+}

--- a/apps/desktop/src/main/vault/attachments.test.ts
+++ b/apps/desktop/src/main/vault/attachments.test.ts
@@ -67,6 +67,21 @@ vi.mock('./index', () => ({
   getStatus: vi.fn(() => ({ path: mockVaultPath, isOpen: true }))
 }))
 
+/**
+ * Who references an attachment is a vault-wide question answered by reading
+ * every note — covered on its own in `attachment-reference-scan.test.ts`. Here
+ * it is a seam, so the delete guard can be exercised in both directions without
+ * standing up an index database.
+ */
+const referenceScan = vi.hoisted(() => ({
+  findNotesReferencingAttachment: vi.fn((_target: { ownerNoteId: string; filename: string }) => ({
+    referencedBy: [] as string[],
+    complete: true
+  }))
+}))
+
+vi.mock('./attachment-reference-scan', () => referenceScan)
+
 // ============================================================================
 // Pure Function Tests - Path Utilities (T391)
 // ============================================================================
@@ -273,6 +288,12 @@ describe('attachment operations', () => {
     const indexModule = await import('./index')
     mockGetStatus = indexModule.getStatus as ReturnType<typeof vi.fn>
     mockGetStatus.mockReturnValue({ path: tempVault.path, isOpen: true })
+
+    referenceScan.findNotesReferencingAttachment.mockReset()
+    referenceScan.findNotesReferencingAttachment.mockReturnValue({
+      referencedBy: [],
+      complete: true
+    })
   })
 
   afterEach(() => {
@@ -411,6 +432,50 @@ describe('attachment operations', () => {
     it('T393: does not throw for non-existent attachment', async () => {
       await expect(deleteAttachment('note123', 'nonexistent.png')).resolves.not.toThrow()
     })
+
+    it('#2077: keeps the file when another note still references it', async () => {
+      const saveResult = await saveAttachment('note123', Buffer.from('pdf'), 'report.pdf')
+      const filename = path.basename(saveResult.path!)
+      referenceScan.findNotesReferencingAttachment.mockReturnValueOnce({
+        referencedBy: ['note-b'],
+        complete: true
+      })
+
+      const outcome = await deleteAttachment('note123', filename)
+
+      expect(outcome).toEqual({ deleted: false, referencedBy: ['note-b'] })
+      expect(fs.existsSync(path.join(tempVault.path, 'attachments', 'note123', filename))).toBe(
+        true
+      )
+    })
+
+    it('#2077: keeps the file when the reference scan could not complete', async () => {
+      const saveResult = await saveAttachment('note123', Buffer.from('pdf'), 'report.pdf')
+      const filename = path.basename(saveResult.path!)
+      referenceScan.findNotesReferencingAttachment.mockReturnValueOnce({
+        referencedBy: [],
+        complete: false
+      })
+
+      const outcome = await deleteAttachment('note123', filename)
+
+      expect(outcome.deleted).toBe(false)
+      expect(fs.existsSync(path.join(tempVault.path, 'attachments', 'note123', filename))).toBe(
+        true
+      )
+    })
+
+    it('#2077: asks about the file the owning note is deleting, excluding itself', async () => {
+      const saveResult = await saveAttachment('note123', Buffer.from('pdf'), 'report.pdf')
+      const filename = path.basename(saveResult.path!)
+
+      await deleteAttachment('note123', filename)
+
+      expect(referenceScan.findNotesReferencingAttachment).toHaveBeenCalledWith(
+        { ownerNoteId: 'note123', filename },
+        { excludeNoteId: 'note123' }
+      )
+    })
   })
 
   describe('deleteNoteAttachments', () => {
@@ -427,6 +492,23 @@ describe('attachment operations', () => {
 
     it('T393: succeeds if folder does not exist', async () => {
       await expect(deleteNoteAttachments('nonexistent')).resolves.not.toThrow()
+    })
+
+    it('#2077: keeps a shared file and the folder holding it', async () => {
+      const shared = await saveAttachment('note123', Buffer.from('pdf'), 'shared.pdf')
+      await saveAttachment('note123', Buffer.from('data'), 'solo.png')
+      const sharedName = path.basename(shared.path!)
+      referenceScan.findNotesReferencingAttachment.mockImplementation((target) =>
+        target.filename === sharedName
+          ? { referencedBy: ['note-b'], complete: true }
+          : { referencedBy: [], complete: true }
+      )
+
+      await deleteNoteAttachments('note123')
+
+      const folder = path.join(tempVault.path, 'attachments', 'note123')
+      expect(fs.existsSync(path.join(folder, sharedName))).toBe(true)
+      expect(fs.readdirSync(folder)).toEqual([sharedName])
     })
   })
 

--- a/apps/desktop/src/main/vault/attachments.test.ts
+++ b/apps/desktop/src/main/vault/attachments.test.ts
@@ -510,6 +510,28 @@ describe('attachment operations', () => {
       expect(fs.existsSync(path.join(folder, sharedName))).toBe(true)
       expect(fs.readdirSync(folder)).toEqual([sharedName])
     })
+
+    it('#2077: keeps the folder when something that is not a file is in it', async () => {
+      await saveAttachment('note123', Buffer.from('data'), 'solo.png')
+      const folder = path.join(tempVault.path, 'attachments', 'note123')
+      fs.mkdirSync(path.join(folder, 'nested'))
+
+      await deleteNoteAttachments('note123')
+
+      // The attachment went; the thing this code does not understand stayed.
+      expect(fs.readdirSync(folder)).toEqual(['nested'])
+    })
+
+    it('#2077: reports a delete failure rather than swallowing it', async () => {
+      await saveAttachment('note123', Buffer.from('data'), 'solo.png')
+      const folder = path.join(tempVault.path, 'attachments', 'note123')
+      fs.chmodSync(folder, 0o500)
+      try {
+        await expect(deleteNoteAttachments('note123')).rejects.toThrow(AttachmentError)
+      } finally {
+        fs.chmodSync(folder, 0o700)
+      }
+    })
   })
 
   describe('listNoteAttachments', () => {

--- a/apps/desktop/src/main/vault/attachments.ts
+++ b/apps/desktop/src/main/vault/attachments.ts
@@ -17,6 +17,7 @@ import { getStatus } from './index'
 import { VaultError, VaultErrorCode } from '../lib/errors'
 import { createLogger } from '../lib/logger'
 import { trackMainError } from '../telemetry/diagnostics'
+import { findNotesReferencingAttachment } from './attachment-reference-scan'
 
 const logger = createLogger('VaultAttachments')
 
@@ -429,32 +430,73 @@ export async function saveAttachment(
   }
 }
 
+export interface DeleteAttachmentOutcome {
+  /** False when the bytes were kept because another note still embeds them. */
+  deleted: boolean
+  /** Note ids that still reference the file; empty whenever `deleted` is true. */
+  referencedBy: string[]
+}
+
 /**
- * Delete a specific attachment
+ * Delete a specific attachment, unless another note still references it (#2077).
  *
- * @param noteId - The note ID
+ * Since "insert existing attachment" exists, `attachments/<noteId>/<file>` is no
+ * longer owned by exactly one note: a second note can embed the same bytes by
+ * pointing at the same path. Unlinking on request would blank that note's embed
+ * with nothing to recover from, so the bytes only go when the owning note is the
+ * last reference — the reference scan, not a stored counter, is the source of
+ * truth, because the references live in note bodies that sync, merge and get
+ * edited outside the app.
+ *
+ * Retaining is reported rather than thrown: the caller asked to detach the file
+ * from this note and that succeeded; the blob simply outlives the request.
+ *
+ * @param noteId - The note ID that owns the attachments folder
  * @param filename - The filename to delete
  */
-export async function deleteAttachment(noteId: string, filename: string): Promise<void> {
+export async function deleteAttachment(
+  noteId: string,
+  filename: string
+): Promise<DeleteAttachmentOutcome> {
   const vaultPath = getVaultPath()
   const filePath = getAttachmentPath(vaultPath, noteId, filename)
+
+  const scan = findNotesReferencingAttachment(
+    { ownerNoteId: noteId, filename },
+    { excludeNoteId: noteId }
+  )
+  if (!scan.complete || scan.referencedBy.length > 0) {
+    logger.info('Attachment kept: another note still references it', {
+      noteId,
+      referenceCount: scan.referencedBy.length,
+      scanComplete: scan.complete
+    })
+    return { deleted: false, referencedBy: scan.referencedBy }
+  }
 
   try {
     await unlink(filePath)
   } catch (error) {
     if (isNodeError(error) && error.code === 'ENOENT') {
       // File already doesn't exist, that's fine
-      return
+      return { deleted: true, referencedBy: [] }
     }
     throw new AttachmentError(
       `Failed to delete attachment: ${filename}`,
       AttachmentErrorCode.DELETE_FAILED
     )
   }
+  return { deleted: true, referencedBy: [] }
 }
 
 /**
- * Delete all attachments for a note (when note is deleted)
+ * Delete this note's attachments, keeping any file another note still embeds.
+ *
+ * Not a `rm -rf` any more (#2077): a shared reference points at
+ * `attachments/<ownerNoteId>/<file>`, so wiping the owner's folder wholesale
+ * would blank a second note's embed. Files go one at a time through the same
+ * reference scan {@link deleteAttachment} uses, and the folder itself is only
+ * removed once it is genuinely empty.
  *
  * @param noteId - The note ID
  */
@@ -467,8 +509,21 @@ export async function deleteNoteAttachments(noteId: string): Promise<void> {
   }
 
   try {
-    await rm(attachmentsDir, { recursive: true, force: true })
-  } catch {
+    const entries = await readdir(attachmentsDir, { withFileTypes: true })
+    let retained = 0
+    for (const entry of entries) {
+      if (!entry.isFile()) {
+        retained++
+        continue
+      }
+      const outcome = await deleteAttachment(noteId, entry.name)
+      if (!outcome.deleted) retained++
+    }
+    if (retained === 0) {
+      await rm(attachmentsDir, { recursive: true, force: true })
+    }
+  } catch (error) {
+    if (error instanceof AttachmentError) throw error
     throw new AttachmentError(
       `Failed to delete attachments folder for note: ${noteId}`,
       AttachmentErrorCode.DELETE_FAILED

--- a/apps/desktop/src/preload/generated-rpc.ts
+++ b/apps/desktop/src/preload/generated-rpc.ts
@@ -117,6 +117,8 @@ export function createGeneratedRpcApi({
         })) as GeneratedRpcApi["notes"]["uploadAttachment"],
       "listAttachments": ((noteId) => invoke("notes:list-attachments", noteId)) as GeneratedRpcApi["notes"]["listAttachments"],
       "deleteAttachment": ((noteId, filename) => invoke("notes:delete-attachment", { noteId, filename })) as GeneratedRpcApi["notes"]["deleteAttachment"],
+      "listVaultAttachments": (() => invoke("notes:list-vault-attachments")) as GeneratedRpcApi["notes"]["listVaultAttachments"],
+      "insertExistingAttachment": ((noteId, ownerNoteId, filename) => invoke("notes:insert-existing-attachment", { noteId, ownerNoteId, filename })) as GeneratedRpcApi["notes"]["insertExistingAttachment"],
       "getFolderConfig": ((folderPath) => invoke("notes:get-folder-config", folderPath)) as GeneratedRpcApi["notes"]["getFolderConfig"],
       "setFolderConfig": ((folderPath, config) => invoke("notes:set-folder-config", { folderPath, config })) as GeneratedRpcApi["notes"]["setFolderConfig"],
       "getFolderTemplate": ((folderPath) => invoke("notes:get-folder-template", folderPath)) as GeneratedRpcApi["notes"]["getFolderTemplate"],

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -86,6 +86,7 @@ import { serializeBlocksPreservingBlanks } from './markdown-utils'
 import { registerEditorPlugin } from './register-editor-plugin'
 import { BlockSideMenuController, duplicateBlock } from './block-side-menu'
 import { MoveBlockDialog } from './move-block-dialog'
+import { InsertExistingAttachmentDialog } from './insert-existing-attachment-dialog'
 import { createMultiBlockIndentPlugin } from './multi-block-indent-plugin'
 import { createBulletCollapsePlugin, BULLET_FOLD_GUTTER } from './bullet-collapse-plugin'
 
@@ -1454,6 +1455,49 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     [editor, noteId, tasksCtx]
   )
 
+  // "Insert existing attachment" (#2077): the picker resolves block props that
+  // point at bytes the vault already stores, so the second note references the
+  // same file instead of getting a copy of it. Nothing is uploaded here — the
+  // owning note's attachment already syncs.
+  const [insertExistingAttachmentOpen, setInsertExistingAttachmentOpen] = useState(false)
+
+  const insertExistingAttachment = useCallback(
+    (result: {
+      url: string
+      name: string
+      size: number
+      mimeType: string
+      type: 'image' | 'file'
+    }): void => {
+      const referenceBlockId = editor.getTextCursorPosition().block.id
+      editor.insertBlocks(
+        [
+          result.type === 'image'
+            ? {
+                type: 'image' as const,
+                props: { url: result.url, caption: result.name, previewWidth: 600 }
+              }
+            : // The same shape `createFileBlockContent` builds, written out here
+              // rather than imported: `file-block.tsx` pulls in react-pdf at
+              // module load, and ContentArea must not drag a PDF renderer in
+              // just to name a block type.
+              {
+                type: 'file' as const,
+                props: {
+                  url: result.url,
+                  name: result.name,
+                  size: result.size,
+                  mimeType: result.mimeType
+                }
+              }
+        ],
+        referenceBlockId,
+        'after'
+      )
+    },
+    [editor]
+  )
+
   // "Move to" from the block side menu: the picker names a target note, then
   // the block's markdown is appended there BEFORE it is removed here. Ordering
   // matters — a failed append must leave the block where it is rather than lose
@@ -1733,6 +1777,14 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
               }}
             />
           )}
+          {insertExistingAttachmentOpen && noteId && (
+            <InsertExistingAttachmentDialog
+              open
+              onOpenChange={(open) => !open && setInsertExistingAttachmentOpen(false)}
+              noteId={noteId}
+              onInsert={insertExistingAttachment}
+            />
+          )}
           {moveBlockId && noteId && (
             <MoveBlockDialog
               open
@@ -1974,9 +2026,21 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
                   group: 'Basic blocks',
                   subtext: t('editor.slashMenu.linkToNote.subtext')
                 }
+                // #2077: embed a file the vault already has. Same group as
+                // `/file` and `/pdf` because it is the same intent — the
+                // difference is that no second copy lands in the vault.
+                const existingAttachmentItem = {
+                  key: 'existing_attachment',
+                  title: t('editor.slashMenu.existingAttachment.title'),
+                  onItemClick: () => setInsertExistingAttachmentOpen(true),
+                  aliases: ['existing', 'reuse', 'attachment', 'shared', 'library'],
+                  group: fileItem?.group ?? 'Basic blocks',
+                  subtext: t('editor.slashMenu.existingAttachment.subtext')
+                }
                 const all = orderSlashMenuItemsByGroup([
                   ...defaults,
                   ...pdfItems,
+                  existingAttachmentItem,
                   calloutItem,
                   ...(taskItem ? [taskItem] : []),
                   ...dateItems,

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -86,7 +86,11 @@ import { serializeBlocksPreservingBlanks } from './markdown-utils'
 import { registerEditorPlugin } from './register-editor-plugin'
 import { BlockSideMenuController, duplicateBlock } from './block-side-menu'
 import { MoveBlockDialog } from './move-block-dialog'
-import { InsertExistingAttachmentDialog } from './insert-existing-attachment-dialog'
+import {
+  InsertExistingAttachmentDialog,
+  buildInsertedAttachmentBlock,
+  type InsertedAttachment
+} from './insert-existing-attachment-dialog'
 import { createMultiBlockIndentPlugin } from './multi-block-indent-plugin'
 import { createBulletCollapsePlugin, BULLET_FOLD_GUTTER } from './bullet-collapse-plugin'
 
@@ -1462,36 +1466,10 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   const [insertExistingAttachmentOpen, setInsertExistingAttachmentOpen] = useState(false)
 
   const insertExistingAttachment = useCallback(
-    (result: {
-      url: string
-      name: string
-      size: number
-      mimeType: string
-      type: 'image' | 'file'
-    }): void => {
-      const referenceBlockId = editor.getTextCursorPosition().block.id
+    (result: InsertedAttachment): void => {
       editor.insertBlocks(
-        [
-          result.type === 'image'
-            ? {
-                type: 'image' as const,
-                props: { url: result.url, caption: result.name, previewWidth: 600 }
-              }
-            : // The same shape `createFileBlockContent` builds, written out here
-              // rather than imported: `file-block.tsx` pulls in react-pdf at
-              // module load, and ContentArea must not drag a PDF renderer in
-              // just to name a block type.
-              {
-                type: 'file' as const,
-                props: {
-                  url: result.url,
-                  name: result.name,
-                  size: result.size,
-                  mimeType: result.mimeType
-                }
-              }
-        ],
-        referenceBlockId,
+        [buildInsertedAttachmentBlock(result)],
+        editor.getTextCursorPosition().block.id,
         'after'
       )
     },

--- a/apps/desktop/src/renderer/src/components/note/content-area/insert-existing-attachment-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/insert-existing-attachment-dialog.test.tsx
@@ -11,12 +11,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   InsertExistingAttachmentDialog,
   attachmentKey,
+  buildInsertedAttachmentBlock,
   filterVaultAttachments
 } from './insert-existing-attachment-dialog'
 
 vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({ t: (key: string) => key })
 }))
+
+const toastError = vi.fn()
+vi.mock('sonner', () => ({ toast: { error: (...args: unknown[]) => toastError(...args) } }))
 
 const listVaultAttachments = vi.fn()
 const insertExistingAttachment = vi.fn()
@@ -33,6 +37,7 @@ function setupApi(): void {
 }
 
 afterEach(() => {
+  toastError.mockReset()
   listVaultAttachments.mockReset()
   insertExistingAttachment.mockReset()
   uploadAttachment.mockReset()
@@ -77,6 +82,47 @@ describe('filterVaultAttachments', () => {
     expect(filterVaultAttachments([PDF, PHOTO], 'REPORT')).toEqual([PDF])
     expect(filterVaultAttachments([PDF, PHOTO], 'trip')).toEqual([PHOTO])
     expect(filterVaultAttachments([PDF, PHOTO], '  ')).toEqual([PDF, PHOTO])
+  })
+})
+
+describe('buildInsertedAttachmentBlock', () => {
+  it('builds an image block for an image, keeping the name as the caption', () => {
+    expect(
+      buildInsertedAttachmentBlock({
+        url: '../attachments/note-c/aaaaaa-photo.png',
+        name: 'photo.png',
+        size: 10,
+        mimeType: 'image/png',
+        type: 'image'
+      })
+    ).toEqual({
+      type: 'image',
+      props: {
+        url: '../attachments/note-c/aaaaaa-photo.png',
+        caption: 'photo.png',
+        previewWidth: 600
+      }
+    })
+  })
+
+  it('builds a file block for everything else, carrying size and mime type', () => {
+    expect(
+      buildInsertedAttachmentBlock({
+        url: '../attachments/note-a/k3f9x2-report.pdf',
+        name: 'report.pdf',
+        size: 2048,
+        mimeType: 'application/pdf',
+        type: 'file'
+      })
+    ).toEqual({
+      type: 'file',
+      props: {
+        url: '../attachments/note-a/k3f9x2-report.pdf',
+        name: 'report.pdf',
+        size: 2048,
+        mimeType: 'application/pdf'
+      }
+    })
   })
 })
 
@@ -132,6 +178,25 @@ describe('InsertExistingAttachmentDialog', () => {
     const rows = await screen.findAllByTestId('insert-existing-attachment-row')
     expect(rows).toHaveLength(1)
     expect(rows[0]).toHaveTextContent('photo.png')
+  })
+
+  it('reports a listing failure and shows nothing rather than a stale list', async () => {
+    listVaultAttachments.mockRejectedValue(new Error('nope'))
+    renderDialog()
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+    expect(screen.queryAllByTestId('insert-existing-attachment-row')).toHaveLength(0)
+  })
+
+  it('reports an insert failure and leaves the note untouched', async () => {
+    listVaultAttachments.mockResolvedValue([PDF])
+    insertExistingAttachment.mockRejectedValue(new Error('gone'))
+    const { onInsert } = renderDialog()
+
+    fireEvent.click(await screen.findByTestId('insert-existing-attachment-row'))
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+    expect(onInsert).not.toHaveBeenCalled()
   })
 
   it('shows the empty state when the vault has no attachments', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/insert-existing-attachment-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/insert-existing-attachment-dialog.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Tests for InsertExistingAttachmentDialog (#2077).
+ *
+ * The dialog's whole job is to turn a picked row into block props that point at
+ * bytes already in the vault, so what is asserted is that it asks main for the
+ * reference and never uploads anything.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  InsertExistingAttachmentDialog,
+  attachmentKey,
+  filterVaultAttachments
+} from './insert-existing-attachment-dialog'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+const listVaultAttachments = vi.fn()
+const insertExistingAttachment = vi.fn()
+const uploadAttachment = vi.fn()
+
+function setupApi(): void {
+  const api = window.api as unknown as Record<string, unknown>
+  api.notes = {
+    ...((api.notes as Record<string, unknown>) ?? {}),
+    listVaultAttachments,
+    insertExistingAttachment,
+    uploadAttachment
+  }
+}
+
+afterEach(() => {
+  listVaultAttachments.mockReset()
+  insertExistingAttachment.mockReset()
+  uploadAttachment.mockReset()
+})
+
+const PDF = {
+  ownerNoteId: 'note-a',
+  ownerNoteTitle: 'Invoices',
+  filename: 'k3f9x2-report.pdf',
+  displayName: 'report.pdf',
+  size: 2048,
+  mimeType: 'application/pdf',
+  type: 'file' as const,
+  modifiedAt: '2026-09-10T00:00:00.000Z'
+}
+
+const PHOTO = {
+  ...PDF,
+  ownerNoteId: 'note-c',
+  ownerNoteTitle: 'Trip',
+  filename: 'aaaaaa-photo.png',
+  displayName: 'photo.png',
+  mimeType: 'image/png',
+  type: 'image' as const
+}
+
+function renderDialog(onInsert = vi.fn()): { onInsert: ReturnType<typeof vi.fn> } {
+  setupApi()
+  render(
+    <InsertExistingAttachmentDialog
+      open
+      onOpenChange={vi.fn()}
+      noteId="note-b"
+      onInsert={onInsert}
+    />
+  )
+  return { onInsert }
+}
+
+describe('filterVaultAttachments', () => {
+  it('matches the file name and the owning note title, case-insensitively', () => {
+    expect(filterVaultAttachments([PDF, PHOTO], 'REPORT')).toEqual([PDF])
+    expect(filterVaultAttachments([PDF, PHOTO], 'trip')).toEqual([PHOTO])
+    expect(filterVaultAttachments([PDF, PHOTO], '  ')).toEqual([PDF, PHOTO])
+  })
+})
+
+describe('attachmentKey', () => {
+  it('keeps two same-named files in different folders distinct', () => {
+    expect(attachmentKey({ ownerNoteId: 'a', filename: 'x.pdf' })).not.toBe(
+      attachmentKey({ ownerNoteId: 'b', filename: 'x.pdf' })
+    )
+  })
+})
+
+describe('InsertExistingAttachmentDialog', () => {
+  it('lists what the vault stores, with the note that owns each file', async () => {
+    listVaultAttachments.mockResolvedValue([PDF, PHOTO])
+    renderDialog()
+
+    const rows = await screen.findAllByTestId('insert-existing-attachment-row')
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toHaveTextContent('report.pdf')
+    expect(rows[0]).toHaveTextContent('Invoices')
+  })
+
+  it('inserts a reference to the picked file without uploading anything', async () => {
+    listVaultAttachments.mockResolvedValue([PDF])
+    const result = {
+      url: '../attachments/note-a/k3f9x2-report.pdf',
+      name: 'report.pdf',
+      filename: PDF.filename,
+      ownerNoteId: 'note-a',
+      size: 2048,
+      mimeType: 'application/pdf',
+      type: 'file' as const
+    }
+    insertExistingAttachment.mockResolvedValue(result)
+    const { onInsert } = renderDialog()
+
+    fireEvent.click(await screen.findByTestId('insert-existing-attachment-row'))
+
+    await waitFor(() => expect(onInsert).toHaveBeenCalledWith(result))
+    expect(insertExistingAttachment).toHaveBeenCalledWith('note-b', 'note-a', PDF.filename)
+    expect(uploadAttachment).not.toHaveBeenCalled()
+  })
+
+  it('narrows the list as the user types', async () => {
+    listVaultAttachments.mockResolvedValue([PDF, PHOTO])
+    renderDialog()
+    await screen.findAllByTestId('insert-existing-attachment-row')
+
+    fireEvent.change(screen.getByTestId('insert-existing-attachment-search'), {
+      target: { value: 'photo' }
+    })
+
+    const rows = await screen.findAllByTestId('insert-existing-attachment-row')
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toHaveTextContent('photo.png')
+  })
+
+  it('shows the empty state when the vault has no attachments', async () => {
+    listVaultAttachments.mockResolvedValue([])
+    renderDialog()
+
+    expect(await screen.findByText('editor.insertExistingAttachment.empty')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/insert-existing-attachment-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/insert-existing-attachment-dialog.tsx
@@ -1,0 +1,187 @@
+/**
+ * InsertExistingAttachmentDialog — embed a file the vault already stores (#2077).
+ *
+ * The point is that nothing is copied: picking a row asks main for the block
+ * props that point at the bytes where they already live
+ * (`attachments/<ownerNoteId>/<file>`), so the same PDF can sit in two notes
+ * without a second copy in the vault and without a second upload.
+ *
+ * @module components/note/content-area/insert-existing-attachment-dialog
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import type { VaultAttachmentEntry } from '@memry/rpc/notes'
+import { useT } from '@memry/i18n/renderer'
+import { notesService } from '@/services/notes-service'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { File, FileText, Image } from '@/lib/icons'
+
+export interface InsertExistingAttachmentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The note that will carry the new block. */
+  noteId: string
+  /** Called with the resolved block props once the user picks a row. */
+  onInsert: (result: {
+    url: string
+    name: string
+    size: number
+    mimeType: string
+    type: 'image' | 'file'
+  }) => void
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function rowIcon(entry: VaultAttachmentEntry): React.ReactNode {
+  if (entry.type === 'image') return <Image className="h-5 w-5 shrink-0 text-muted-foreground" />
+  if (entry.mimeType === 'application/pdf')
+    return <FileText className="h-5 w-5 shrink-0 text-red-500" />
+  return <File className="h-5 w-5 shrink-0 text-muted-foreground" />
+}
+
+/** Stable key: the identity of a stored blob is its folder plus its name. */
+export function attachmentKey(entry: { ownerNoteId: string; filename: string }): string {
+  return `${entry.ownerNoteId}/${entry.filename}`
+}
+
+/** Case-insensitive match over what the row actually shows. */
+export function filterVaultAttachments(
+  entries: VaultAttachmentEntry[],
+  query: string
+): VaultAttachmentEntry[] {
+  const trimmed = query.trim().toLowerCase()
+  if (!trimmed) return entries
+  return entries.filter(
+    (entry) =>
+      entry.displayName.toLowerCase().includes(trimmed) ||
+      (entry.ownerNoteTitle?.toLowerCase().includes(trimmed) ?? false)
+  )
+}
+
+export function InsertExistingAttachmentDialog({
+  open,
+  onOpenChange,
+  noteId,
+  onInsert
+}: InsertExistingAttachmentDialogProps) {
+  const { t } = useT('notes')
+  const [entries, setEntries] = useState<VaultAttachmentEntry[]>([])
+  const [query, setQuery] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  // Reopening — even on the same note — flips `loading` back on during render
+  // rather than from an effect, the way NoteAttachmentsDialog does.
+  const openKey = open ? noteId : null
+  const [loadedKey, setLoadedKey] = useState(openKey)
+  if (openKey !== loadedKey) {
+    setLoadedKey(openKey)
+    if (openKey !== null) {
+      setLoading(true)
+      setQuery('')
+    }
+  }
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    notesService
+      .listVaultAttachments()
+      .then((rows) => {
+        if (!cancelled) setEntries(rows)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setEntries([])
+        toast.error(extractErrorMessage(err, t('editor.insertExistingAttachment.loadFailed')))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+    // `t` is not identity-stable across renders; the dialog reloads on open only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  const visible = useMemo(() => filterVaultAttachments(entries, query), [entries, query])
+
+  const pick = useCallback(
+    async (entry: VaultAttachmentEntry) => {
+      try {
+        const result = await notesService.insertExistingAttachment(
+          noteId,
+          entry.ownerNoteId,
+          entry.filename
+        )
+        onInsert(result)
+        onOpenChange(false)
+      } catch (err) {
+        toast.error(extractErrorMessage(err, t('editor.insertExistingAttachment.insertFailed')))
+      }
+    },
+    [noteId, onInsert, onOpenChange, t]
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg" data-testid="insert-existing-attachment-dialog">
+        <DialogHeader>
+          <DialogTitle>{t('editor.insertExistingAttachment.title')}</DialogTitle>
+          <DialogDescription>{t('editor.insertExistingAttachment.description')}</DialogDescription>
+        </DialogHeader>
+        <Input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t('editor.insertExistingAttachment.searchPlaceholder')}
+          data-testid="insert-existing-attachment-search"
+        />
+        {!loading && visible.length === 0 ? (
+          <p className="py-4 text-sm text-muted-foreground">
+            {t('editor.insertExistingAttachment.empty')}
+          </p>
+        ) : (
+          <ul className="max-h-80 space-y-1 overflow-y-auto">
+            {visible.map((entry) => (
+              <li key={attachmentKey(entry)}>
+                <button
+                  type="button"
+                  data-testid="insert-existing-attachment-row"
+                  onClick={() => void pick(entry)}
+                  className="flex w-full items-center gap-3 rounded-md border border-border p-2 text-start hover:bg-accent"
+                >
+                  {rowIcon(entry)}
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium" title={entry.displayName}>
+                      {entry.displayName}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {entry.ownerNoteTitle
+                        ? `${entry.ownerNoteTitle} · ${formatFileSize(entry.size)}`
+                        : formatFileSize(entry.size)}
+                    </p>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/content-area/insert-existing-attachment-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/insert-existing-attachment-dialog.tsx
@@ -25,19 +25,48 @@ import {
 import { Input } from '@/components/ui/input'
 import { File, FileText, Image } from '@/lib/icons'
 
+/** What main hands back for a picked attachment; the block props come from it. */
+export interface InsertedAttachment {
+  url: string
+  name: string
+  size: number
+  mimeType: string
+  type: 'image' | 'file'
+}
+
+/**
+ * The BlockNote block for an attachment that is already in the vault.
+ *
+ * Lives here rather than in ContentArea so it can be tested without mounting
+ * the editor, and written out rather than calling `createFileBlockContent`
+ * because `file-block.tsx` pulls in react-pdf at module load — naming a block
+ * type must not drag a PDF renderer in with it.
+ */
+export function buildInsertedAttachmentBlock(result: InsertedAttachment) {
+  if (result.type === 'image') {
+    return {
+      type: 'image' as const,
+      props: { url: result.url, caption: result.name, previewWidth: 600 }
+    }
+  }
+  return {
+    type: 'file' as const,
+    props: {
+      url: result.url,
+      name: result.name,
+      size: result.size,
+      mimeType: result.mimeType
+    }
+  }
+}
+
 export interface InsertExistingAttachmentDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   /** The note that will carry the new block. */
   noteId: string
   /** Called with the resolved block props once the user picks a row. */
-  onInsert: (result: {
-    url: string
-    name: string
-    size: number
-    mimeType: string
-    type: 'image' | 'file'
-  }) => void
+  onInsert: (result: InsertedAttachment) => void
 }
 
 function formatFileSize(bytes: number): string {

--- a/apps/desktop/tests/e2e/shared-attachment-reference.e2e.ts
+++ b/apps/desktop/tests/e2e/shared-attachment-reference.e2e.ts
@@ -1,0 +1,184 @@
+/**
+ * Shared attachment references E2E (issue #2077).
+ *
+ * One PDF, two notes, one blob. Covers the user-visible insert path end to end
+ * against a real vault on disk:
+ *  - `/existing attachment` in the second note lists what the vault stores and
+ *    inserts a ref into the FIRST note's attachments folder;
+ *  - no second copy of the bytes lands anywhere;
+ *  - the relationship survives a restart (the note body on disk still resolves);
+ *  - deleting the attachment from the owning note keeps the bytes while the
+ *    second note still references them.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel, minimalPdfBytes } from './utils/desktop-test-helpers'
+import { SELECTORS } from './utils/electron-helpers'
+
+const ORIGINAL_NAME = 'shared-report.pdf'
+
+test.describe('Shared attachment references', () => {
+  test('one PDF inserted into a second note stores one blob and survives a restart', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+
+    const ownerTitle = uniqueLabel('Shared Owner')
+    const borrowerTitle = uniqueLabel('Shared Borrower')
+
+    // Note A uploads the PDF; note B is created empty and opened.
+    const seeded = await page.evaluate(
+      async ({ ownerTitle, borrowerTitle, fileName, bytes }) => {
+        const api = window.api
+
+        const owner = await api.notes.create({ title: ownerTitle, content: 'owns the pdf' })
+        if (!owner.success || !owner.note) throw new Error(owner.error ?? 'owner create failed')
+
+        const file = new File([new Uint8Array(bytes)], fileName, { type: 'application/pdf' })
+        const uploaded = await api.notes.uploadAttachment(owner.note.id, file)
+        if (!uploaded.success) throw new Error(uploaded.error ?? 'upload failed')
+
+        const attachments = await api.notes.listAttachments(owner.note.id)
+        const storedFilename = attachments[0]?.filename
+        if (!storedFilename) throw new Error('uploaded attachment not listed')
+
+        const borrower = await api.notes.create({ title: borrowerTitle, content: '' })
+        if (!borrower.success || !borrower.note) {
+          throw new Error(borrower.error ?? 'borrower create failed')
+        }
+
+        return {
+          ownerNoteId: owner.note.id,
+          borrowerNoteId: borrower.note.id,
+          storedFilename
+        }
+      },
+      {
+        ownerTitle,
+        borrowerTitle,
+        fileName: ORIGINAL_NAME,
+        bytes: [...minimalPdfBytes()]
+      }
+    )
+
+    await restoreSingleNoteTab(page, testVaultPath, seeded.borrowerNoteId, borrowerTitle)
+
+    // The user-visible path: `/` slash menu → "Existing attachment" → pick.
+    const editor = page.locator(SELECTORS.noteEditor).first()
+    await editor.click()
+    await page.keyboard.type('/existing')
+
+    await page.getByText('Existing attachment', { exact: true }).first().click()
+
+    const dialog = page.getByTestId('insert-existing-attachment-dialog')
+    await expect(dialog).toBeVisible()
+
+    const row = dialog.getByTestId('insert-existing-attachment-row').filter({
+      hasText: ORIGINAL_NAME
+    })
+    await expect(row).toHaveCount(1)
+    await row.click()
+    await expect(dialog).toBeHidden()
+
+    // The block renders from the OWNER's folder. A PDF renders as the inline
+    // preview rather than the plain file card, so key on the preview's scroller.
+    await page
+      .getByTestId('pdf-embed-scroll')
+      .first()
+      .waitFor({ state: 'visible', timeout: 20_000 })
+
+    // One blob, in the owner's folder only. The borrower never got a copy.
+    const ownerDir = path.join(testVaultPath, 'attachments', seeded.ownerNoteId)
+    const borrowerDir = path.join(testVaultPath, 'attachments', seeded.borrowerNoteId)
+    expect(fs.readdirSync(ownerDir)).toEqual([seeded.storedFilename])
+    expect(fs.existsSync(borrowerDir)).toBe(false)
+
+    // Restart: the ref on disk still resolves to the one blob.
+    await page.reload()
+    await ready(page)
+    await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 20_000 })
+    await page
+      .getByTestId('pdf-embed-scroll')
+      .first()
+      .waitFor({ state: 'visible', timeout: 20_000 })
+    await expect(page.getByTestId('attachment-missing-card')).toHaveCount(0)
+
+    // The ref the note actually carries, read off disk — it names the OWNER's
+    // folder, at whatever depth the borrowing note happens to sit.
+    const borrowerNote = await page.evaluate(
+      (id) => window.api.notes.get(id),
+      seeded.borrowerNoteId
+    )
+    const borrowerBody = fs.readFileSync(path.join(testVaultPath, borrowerNote!.path), 'utf-8')
+    const refMatch = borrowerBody.match(/"url":"([^"]+)"/)
+    expect(refMatch?.[1]).toContain(`attachments/${seeded.ownerNoteId}/${seeded.storedFilename}`)
+
+    const resolved = await page.evaluate(
+      ({ borrowerNoteId, url }) => window.api.notes.resolveAttachment(borrowerNoteId, url),
+      { borrowerNoteId: seeded.borrowerNoteId, url: refMatch![1] }
+    )
+    expect(resolved.exists).toBe(true)
+    expect(resolved.storedFilename).toBe(seeded.storedFilename)
+
+    // Deleting from the OWNING note must not take the borrower's embed with it.
+    const deletion = await page.evaluate(
+      ({ ownerNoteId, storedFilename }) =>
+        window.api.notes.deleteAttachment(ownerNoteId, storedFilename),
+      seeded
+    )
+    expect(deletion.success).toBe(true)
+    expect(deletion.deleted).toBe(false)
+    expect(deletion.referencedBy).toContain(seeded.borrowerNoteId)
+    expect(fs.existsSync(path.join(ownerDir, seeded.storedFilename))).toBe(true)
+  })
+})
+
+/**
+ * Open one note through the restored-session pattern the other attachment specs
+ * use: tab state is seeded into localStorage, then the window is reloaded.
+ */
+async function restoreSingleNoteTab(
+  page: import('@playwright/test').Page,
+  vaultPath: string,
+  noteId: string,
+  title: string
+): Promise<void> {
+  await page.addInitScript(
+    ({ noteId, t, storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          version: 2,
+          tabGroups: {
+            g1: {
+              id: 'g1',
+              activeTabId: 'note-tab',
+              tabs: [
+                {
+                  id: 'note-tab',
+                  type: 'note',
+                  title: t,
+                  icon: 'file',
+                  path: `/notes/${noteId}`,
+                  entityId: noteId,
+                  isPinned: false
+                }
+              ]
+            }
+          },
+          layout: { type: 'leaf', tabGroupId: 'g1' },
+          activeGroupId: 'g1',
+          settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' },
+          savedAt: Date.now()
+        })
+      )
+    },
+    { noteId, t: title, storageKey: `memry_tab_state:${vaultPath}` }
+  )
+  await page.reload()
+  await ready(page)
+  await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 20_000 })
+}

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -12,6 +12,7 @@ Three ways:
 - **Drag from your OS file manager** — drop a file onto the editor at the position you want it. The file is **copied** into the vault attachments directory (`<vault>/attachments/`), so the original on your filesystem can be moved or deleted without breaking the note.
 - **Drag from the sidebar** — drag a file item (PDF, image, audio, …) from the left sidebar onto a note. This **embeds it by reference** using the item's own vault path, so no second copy is made.
 - **Slash menu** — `/file` inserts a File block; click to pick a file.
+- **Reuse a file the vault already has** — `/existing attachment` opens a picker listing every attachment in the vault, with the note each one is stored under. Picking one embeds it **by reference**, so the same PDF can sit in two notes without a second copy.
 
 While you drag over a note, a line marks where the file will land, and dropping inserts it exactly there. The line follows the cursor once per frame instead of on every pointer event, so dragging over a long note stays smooth.
 
@@ -152,11 +153,34 @@ are absolute paths (including Windows `\\server\share` style ones) and `http(s)`
 URLs. If an image shows up broken, check that the referenced file actually sits
 where the path points, relative to the note.
 
+### One File, Several Notes
+
+An attachment is stored once, under the note it was first added to
+(`<vault>/attachments/<note-id>/`), and it stays there. When a second note embeds
+it through `/existing attachment`, that note simply points at the same file —
+nothing is copied, nothing is uploaded again, and the two embeds stay
+independent blocks you can resize, align or remove separately.
+
+A few consequences worth knowing:
+
+- **Removing the embed from one note leaves the other alone.** A file is only
+  deleted from disk once no note references it any more; while a second note
+  still does, the bytes stay.
+- **Moving either note is fine.** The reference is recomputed against the note's
+  new folder, so it keeps naming the same file.
+- **Sync carries one blob.** The note that stores the file syncs it; on the other
+  device both embeds resolve against that single copy.
+- **Renaming is done from the owning note.** The rename action is only offered
+  for files stored under the note you are in. If the owner renames a file, a
+  borrowing note's embed self-heals by prefix on the next load.
+- **Files you already duplicated stay duplicated.** Memry never collapses two
+  existing copies of the same file behind your back.
+
 ## Removing or Replacing
 
 Click the file block menu to:
 
-- **Delete** — removes the block from the note; the underlying file stays in the attachments dir until garbage collection
+- **Delete** — removes the block from the note; the underlying file stays in the attachments dir until garbage collection, and is never removed while another note still references it
 - **Replace** — swap the bound file without re-creating the block
 
 ## Storage

--- a/packages/contracts/src/notes-api.ts
+++ b/packages/contracts/src/notes-api.ts
@@ -185,6 +185,49 @@ export interface AttachmentRenameResult {
   name: string
 }
 
+export const InsertExistingAttachmentSchema = z.object({
+  /** The note that will carry the new block. */
+  noteId: z.string(),
+  /** The note whose `attachments/<id>/` folder stores the bytes. */
+  ownerNoteId: z.string(),
+  /** Stored basename inside that folder, e.g. `k3f9x2-report.pdf` */
+  filename: z.string().min(1)
+})
+
+/**
+ * One stored attachment anywhere in the vault (#2077).
+ *
+ * Identity is `(ownerNoteId, filename)` — the folder the bytes live in plus
+ * their name. That pair is what a second note references; nothing is copied.
+ */
+export interface VaultAttachmentEntry {
+  ownerNoteId: string
+  /** Null when the owning note is no longer in the index; the bytes still are. */
+  ownerNoteTitle: string | null
+  /** Stored basename, e.g. `k3f9x2-report.pdf` */
+  filename: string
+  /** The stored basename without its nanoid prefix, for display. */
+  displayName: string
+  size: number
+  mimeType: string
+  type: 'image' | 'file'
+  /** File mtime, ISO-8601. The picker lists newest first. */
+  modifiedAt: string
+}
+
+/** Block props for an embed that points at an already-stored attachment. */
+export interface InsertExistingAttachmentResult {
+  /** Ref for the block's `url` prop, relative to the receiving note. */
+  url: string
+  /** Display name for the block's `name` prop. */
+  name: string
+  filename: string
+  ownerNoteId: string
+  size: number
+  mimeType: string
+  type: 'image' | 'file'
+}
+
 export interface AttachmentResolveResult {
   /** Absolute on-disk path, remapped to this device's vault for cross-device notes */
   absolutePath: string

--- a/packages/contracts/src/notes-channels.ts
+++ b/packages/contracts/src/notes-channels.ts
@@ -85,6 +85,10 @@ export const NotesChannels = {
     ATTACHMENT_OPEN_EXTERNAL: 'notes:attachment-open-external',
     /** Rename an attachment on disk, keeping its nanoid prefix and extension */
     ATTACHMENT_RENAME: 'notes:attachment-rename',
+    /** Every attachment stored anywhere in the vault, for the "insert existing" picker */
+    LIST_VAULT_ATTACHMENTS: 'notes:list-vault-attachments',
+    /** Block props for embedding an attachment another note already stores */
+    INSERT_EXISTING_ATTACHMENT: 'notes:insert-existing-attachment',
     /** Get folder config (template settings) */
     GET_FOLDER_CONFIG: 'notes:get-folder-config',
     /** Set folder config (template settings) */

--- a/packages/editor-schema/src/blocks/rewrite-note-refs.test.ts
+++ b/packages/editor-schema/src/blocks/rewrite-note-refs.test.ts
@@ -31,6 +31,23 @@ describe('rewriteNoteRefsForMove', () => {
     )
   })
 
+  it('re-points a shared ref at the OWNING note’s folder, not its own (#2077)', () => {
+    // `n2` embeds a file stored under `n1`. Moving n2 must keep the ref aimed
+    // at `attachments/n1/`, or the second note's embed goes blank while the
+    // bytes sit untouched on disk.
+    const body =
+      '<!-- file:{"url":"../attachments/n1/k3f9x2-report.pdf","name":"report.pdf","size":1,"mimeType":"application/pdf"} -->\n'
+
+    expect(
+      rewriteNoteRefsForMove(body, 'notes/B.md', 'notes/archive/2026/B.md', {
+        sourceNoteId: 'n2',
+        preserveRootRelativeAttachments: true
+      })
+    ).toBe(
+      '<!-- file:{"url":"../../../attachments/n1/k3f9x2-report.pdf","name":"report.pdf","size":1,"mimeType":"application/pdf"} -->\n'
+    )
+  })
+
   it('drops the `../` the note no longer needs when it moves up', () => {
     const body = '![photo](../../../attachments/n1/photo.png)\n'
 

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -237,6 +237,10 @@
       "linkToNote": {
         "title": "Link to note",
         "subtext": "Search notes — or type [[ anywhere"
+      },
+      "existingAttachment": {
+        "title": "Existing attachment",
+        "subtext": "Embed a file already in this vault — no second copy"
       }
     },
     "filePanel": {
@@ -277,6 +281,14 @@
         "moved": "Block moved to “{title}”",
         "failed": "Could not move the block"
       }
+    },
+    "insertExistingAttachment": {
+      "title": "Insert existing attachment",
+      "description": "Embed a file this vault already stores. Nothing is copied — both notes point at the same file.",
+      "searchPlaceholder": "Search attachments…",
+      "empty": "No attachments in this vault yet.",
+      "loadFailed": "Failed to load the vault's attachments",
+      "insertFailed": "Failed to insert the attachment"
     }
   },
   "dateMention": {

--- a/packages/rpc/src/notes.ts
+++ b/packages/rpc/src/notes.ts
@@ -7,6 +7,8 @@ import type {
 import type {
   AttachmentRenameResult,
   AttachmentResolveResult,
+  InsertExistingAttachmentResult,
+  VaultAttachmentEntry,
   NoteSizeClass,
   NoteLargeFileInfo,
   LargeFileOpenResult,
@@ -200,9 +202,19 @@ export interface AttachmentUploadFile {
   arrayBuffer(): Promise<ArrayBuffer>
 }
 
+export type { InsertExistingAttachmentResult, VaultAttachmentEntry }
+
 export interface DeleteAttachmentResponse {
   success: boolean
   error?: string
+  /**
+   * False when the bytes were kept because another note still embeds them
+   * (#2077). Absent on responses from older main processes, so read it as
+   * "deleted" only when it is explicitly `false`.
+   */
+  deleted?: boolean
+  /** Note ids that still reference the file; empty whenever `deleted` is true. */
+  referencedBy?: string[]
 }
 
 export interface FolderConfig {
@@ -682,6 +694,23 @@ export const notesRpc = defineDomain({
       channel: NotesChannels.invoke.DELETE_ATTACHMENT,
       params: ['noteId', 'filename'],
       invokeArgs: ['{ noteId, filename }']
+    }),
+    // #2077: the "insert existing attachment" pair. The picker lists what the
+    // vault already stores; the insert returns block props pointing at those
+    // same bytes, so two notes share one blob instead of copying it.
+    listVaultAttachments: defineMethod<() => Promise<VaultAttachmentEntry[]>>({
+      channel: NotesChannels.invoke.LIST_VAULT_ATTACHMENTS
+    }),
+    insertExistingAttachment: defineMethod<
+      (
+        noteId: string,
+        ownerNoteId: string,
+        filename: string
+      ) => Promise<InsertExistingAttachmentResult>
+    >({
+      channel: NotesChannels.invoke.INSERT_EXISTING_ATTACHMENT,
+      params: ['noteId', 'ownerNoteId', 'filename'],
+      invokeArgs: ['{ noteId, ownerNoteId, filename }']
     }),
     getFolderConfig: defineMethod<(folderPath: string) => Promise<FolderConfig | null>>({
       channel: NotesChannels.invoke.GET_FOLDER_CONFIG,


### PR DESCRIPTION
## Summary

Closes #2077.

A user wanted the same PDF in two notes without a second copy in the vault.

Attachment bytes already live at `attachments/<ownerNoteId>/<storedFilename>` and never move, so that pair is already a stable vault-wide identity — the one the existing note-relative ref encodes. A second note embeds the same blob by writing that same target relative to its own folder. **No new record, no new format, no migration**: resolve, self-heal, cross-device remap, move rewriting and the markdown serializer all understand a shared ref unchanged, and older vaults read exactly as before.

What changed:

- **Insert path** — `/existing attachment` in the slash menu opens a picker listing every attachment the vault stores, with the note that owns each one, searchable by file name or note title. Picking one inserts a file or image block pointing at those bytes. Nothing is copied, nothing is uploaded again.
- **Reference-safe deletion** — `deleteAttachment` scans note bodies (journals included) for `attachments/<owner>/<file>` before unlinking and keeps the file while any other note references it. An index it cannot read fails closed: "unknown" never licenses a deletion. `deleteNoteAttachments` stopped being a `rm -rf` for the same reason and now removes the folder only once it is genuinely empty.
- **No auto-dedupe** — two notes that each uploaded the same PDF keep their own copies. Collapsing them would rewrite bodies the user did not ask us to touch.

Design decisions and assumptions:

- Identity is `(ownerNoteId, storedFilename)`, carried in the ref itself, not a new id column. A stored refcount would drift the moment a body is edited outside the app or merged by CRDT sync; the note bodies are the only honest source of truth, and delete is rare enough to afford the scan.
- Sync needs no change: the owning note carries the blob to every device, and the borrowing note's ref resolves against that single copy once it lands.
- Rename is still only offered for files the current note owns (pre-existing guard). If the owner renames a file, a borrowing note's embed self-heals by nanoid prefix on the next load — covered by a test.
- Note moves are covered by the existing ref arithmetic, which re-points at the *owner's* folder rather than the moving note's — also covered by a test.

## Backward compatibility / migration plan

No migration. Nothing on disk or in the DB changes shape:

- Vault file format: unchanged. A shared ref is the same `../attachments/<id>/<file>` string the app has always written — only the `<id>` may belong to another note. Older app versions resolve it through the exact same code path.
- DB: no schema change. One additive read-only query (`getAllNoteRefRows`).
- IPC contracts: two new channels (`notes:list-vault-attachments`, `notes:insert-existing-attachment`). `DeleteAttachmentResponse` gains **optional** `deleted` / `referencedBy`; they are absent from older main processes, so callers must read `deleted === false` rather than `!deleted`.
- Sync protocol: untouched.
- Behavior change worth knowing: `notes:delete-attachment` can now report `deleted: false`. That is strictly safer than before — the old behavior could unlink bytes another note pointed at.

## Release note

Embed a file the vault already stores in a second note with `/existing attachment` — one copy, two notes. Deleting an attachment now keeps the file while any other note still references it.

## Test plan

- `pnpm lint`, `pnpm typecheck`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm ipc:generate && pnpm ipc:check`, `pnpm --filter @memry/desktop i18n:check`, `git diff --check` — all clean.
- `pnpm --filter @memry/desktop test:main` — 579 files, 8161 tests passing.
- `pnpm --filter @memry/desktop test:renderer` — passing (732 files).
- `pnpm --filter @memry/editor-schema` rewrite-note-refs suite — passing.
- New unit coverage:
  - `attachment-reference-scan.test.ts` — finds note-relative, mobile root-relative and legacy absolute refs; finds journal refs; ignores a same-named file in another folder; excludes the asking note; fails closed on an unreadable index.
  - `attachment-references.test.ts` — listing, owner titles, orphaned folders, extension gating; ref built from the receiving note's depth; **copies nothing**; traversal refused.
  - `attachments.test.ts` — delete keeps a file another note references, keeps it when the scan is incomplete, and `deleteNoteAttachments` keeps a shared file and the folder holding it.
  - `attachment-actions.test.ts` — a shared ref resolves, and self-heals after the owner renames the file.
  - `insert-existing-attachment-dialog.test.tsx` — lists, filters, inserts by reference, never calls `uploadAttachment`.
  - `rewrite-note-refs.test.ts` — a move re-points a shared ref at the owner's folder.
- New E2E `tests/e2e/shared-attachment-reference.e2e.ts` (run alone, passing): upload one PDF to note A, `/existing` → pick in note B, assert one blob in A's folder and no folder for B, restart, assert the ref on disk still resolves, then assert deleting from A returns `deleted: false` and leaves the bytes.
- Docs: `apps/docs/src/user-guide/notes/attachments.md` updated; `pnpm docs:build` passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)