### PR TITLE
Stop a folder-table tag edit from destroying a PDF

### DIFF
--- a/apps/desktop/src/main/ipc/folder-view-handlers.ts
+++ b/apps/desktop/src/main/ipc/folder-view-handlers.ts
@@ -336,7 +336,8 @@ export function registerFolderViewHandlers(): void {
             // TagItem carries no word count for any kind.
             wordCount: 0,
             properties: propertiesMap.get(item.id) ?? {},
-            kind: item.kind
+            kind: item.kind,
+            fileType: 'markdown'
           }))
 
           const page = rows.slice(input.offset, input.offset + input.limit)
@@ -364,7 +365,10 @@ export function registerFolderViewHandlers(): void {
             emoji: noteCache.emoji,
             created: noteCache.createdAt,
             modified: noteCache.modifiedAt,
-            wordCount: noteCache.wordCount
+            wordCount: noteCache.wordCount,
+            // #2073: the renderer has to know a PDF row from a note row so its
+            // metadata cells stay read-only instead of rewriting the binary.
+            fileType: noteCache.fileType
           })
           .from(noteCache)
           .where(and(like(noteCache.path, pathPattern), isNull(noteCache.date)))
@@ -414,7 +418,8 @@ export function registerFolderViewHandlers(): void {
           created: note.created,
           modified: note.modified,
           wordCount: note.wordCount ?? 0,
-          properties: propertiesMap.get(note.id) || {}
+          properties: propertiesMap.get(note.id) || {},
+          fileType: note.fileType ?? 'markdown'
         }))
 
         // Count total (simplified - just use current batch)

--- a/apps/desktop/src/main/lib/errors.ts
+++ b/apps/desktop/src/main/lib/errors.ts
@@ -35,7 +35,9 @@ export const NoteErrorCode = {
   WRITE_FAILED: 'NOTE_WRITE_FAILED',
   READ_FAILED: 'NOTE_READ_FAILED',
   DELETE_FAILED: 'NOTE_DELETE_FAILED',
-  INVALID_PATH: 'NOTE_INVALID_PATH'
+  INVALID_PATH: 'NOTE_INVALID_PATH',
+  /** The target is a binary file (PDF, image, audio, video), not a markdown note. */
+  NOT_MARKDOWN: 'NOTE_NOT_MARKDOWN'
 } as const
 
 export type NoteErrorCode = (typeof NoteErrorCode)[keyof typeof NoteErrorCode]

--- a/apps/desktop/src/main/vault/binary-metadata-safety.test.ts
+++ b/apps/desktop/src/main/vault/binary-metadata-safety.test.ts
@@ -1,0 +1,179 @@
+/**
+ * #2073 — a non-markdown file in the vault is binary content. Editing its Memry
+ * metadata (tags, properties, frontmatter) from the folder table must never
+ * decode it as UTF-8, never pass it through the markdown/frontmatter serializer
+ * and never replace its bytes.
+ *
+ * @module vault/binary-metadata-safety.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import { createHash } from 'crypto'
+import { createTestVault, type TestVaultResult } from '@tests/utils/test-vault'
+import { createTestDataDb, createTestIndexDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import type { VaultStatus, VaultConfig } from '@memry/contracts/vault-api'
+import { startProjectionRuntime, stopProjectionRuntime } from '../projections'
+import { createNoteDerivedStateProjector } from '../projections/projectors/note-derived-state-projector'
+
+vi.mock('electron', () => {
+  const mockWebContents = { send: vi.fn() }
+  const mockWindow = { isDestroyed: () => false, webContents: mockWebContents }
+
+  return {
+    BrowserWindow: { getAllWindows: vi.fn(() => [mockWindow]) },
+    shell: { openPath: vi.fn(() => Promise.resolve('')), showItemInFolder: vi.fn() }
+  }
+})
+
+vi.mock('../inbox/suggestions', () => ({
+  updateNoteEmbedding: vi.fn(() => Promise.resolve())
+}))
+
+/** Minimal but real PDF: header, binary comment line, one object, trailer, EOF. */
+const PDF_BYTES = Buffer.from(
+  '255044462d312e340a25e2e3cfd30a312030206f626a0a3c3c2f547970652f436174616c6f673e3e0a' +
+    '656e646f626a0a747261696c65720a3c3c2f526f6f742031203020523e3e0a2525454f460a',
+  'hex'
+)
+
+/** A PNG signature plus a chunk of bytes that are not valid UTF-8. */
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xd8, 0xc0, 0x80, 0x00, 0x01
+])
+
+function sha256(filePath: string): string {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
+
+describe('binary file metadata safety (#2073)', () => {
+  let tempVault: TestVaultResult
+  let dataDb: TestDatabaseResult
+  let testDb: TestDatabaseResult
+
+  let vaultIndex: typeof import('./index')
+  let database: typeof import('../database')
+  let notes: typeof import('./notes')
+
+  beforeEach(async () => {
+    tempVault = createTestVault('binary-metadata-safety')
+    dataDb = createTestDataDb()
+    testDb = createTestIndexDb()
+
+    vaultIndex = await import('./index')
+    database = await import('../database')
+    notes = await import('./notes')
+
+    vi.spyOn(vaultIndex, 'getStatus').mockReturnValue({
+      isOpen: true,
+      path: tempVault.path,
+      isIndexing: false,
+      indexProgress: 100,
+      error: null
+    } satisfies VaultStatus)
+
+    vi.spyOn(vaultIndex, 'getConfig').mockReturnValue({
+      excludePatterns: ['.git', 'node_modules', '.trash'],
+      defaultNoteFolder: 'notes',
+      journalFolder: 'journal',
+      journalDateFormat: 'YYYY-MM-DD',
+      attachmentsFolder: 'attachments'
+    } satisfies VaultConfig)
+
+    vi.spyOn(database, 'getDatabase').mockReturnValue(
+      dataDb.db as unknown as ReturnType<typeof database.getDatabase>
+    )
+    vi.spyOn(database, 'getIndexDatabase').mockReturnValue(
+      testDb.db as unknown as ReturnType<typeof database.getIndexDatabase>
+    )
+    vi.spyOn(database, 'updateFtsContent').mockImplementation(() => {})
+
+    startProjectionRuntime([createNoteDerivedStateProjector(() => tempVault.path)])
+  })
+
+  afterEach(async () => {
+    await stopProjectionRuntime()
+    vi.restoreAllMocks()
+    testDb.close()
+    dataDb.close()
+    tempVault.cleanup()
+  })
+
+  async function seedBinary(
+    id: string,
+    fileName: string,
+    fileType: 'pdf' | 'image',
+    bytes: Buffer
+  ): Promise<{ absolutePath: string; sha: string }> {
+    const absolutePath = path.join(tempVault.notesDir, fileName)
+    fs.writeFileSync(absolutePath, bytes)
+
+    const { insertNoteCache } = await import('@main/database/queries/notes')
+    insertNoteCache(testDb.db, {
+      id,
+      path: `notes/${fileName}`,
+      title: path.basename(fileName, path.extname(fileName)),
+      fileType,
+      mimeType: fileType === 'pdf' ? 'application/pdf' : 'image/png',
+      fileSize: bytes.length,
+      createdAt: '2026-01-15T12:00:00.000Z',
+      modifiedAt: '2026-01-15T12:00:00.000Z'
+    })
+
+    return { absolutePath, sha: sha256(absolutePath) }
+  }
+
+  it('rejects a tag edit on a PDF row and leaves the bytes untouched', async () => {
+    const { absolutePath, sha } = await seedBinary('pdf-tag-1', 'invoice.pdf', 'pdf', PDF_BYTES)
+
+    await expect(notes.updateNote({ id: 'pdf-tag-1', tags: ['invoice'] })).rejects.toMatchObject({
+      code: 'NOTE_NOT_MARKDOWN'
+    })
+
+    expect(sha256(absolutePath)).toBe(sha)
+    expect(Buffer.compare(fs.readFileSync(absolutePath), PDF_BYTES)).toBe(0)
+  })
+
+  it('rejects a tag edit on an image row and leaves the bytes untouched', async () => {
+    const { absolutePath, sha } = await seedBinary('png-tag-1', 'photo.png', 'image', PNG_BYTES)
+
+    await expect(notes.updateNote({ id: 'png-tag-1', tags: ['holiday'] })).rejects.toMatchObject({
+      code: 'NOTE_NOT_MARKDOWN'
+    })
+
+    expect(sha256(absolutePath)).toBe(sha)
+    expect(Buffer.compare(fs.readFileSync(absolutePath), PNG_BYTES)).toBe(0)
+  })
+
+  it('rejects a property edit reachable from the same folder table row', async () => {
+    const { absolutePath, sha } = await seedBinary('pdf-prop-1', 'report.pdf', 'pdf', PDF_BYTES)
+
+    await expect(
+      notes.updateNote({ id: 'pdf-prop-1', properties: { status: 'review' } })
+    ).rejects.toMatchObject({ code: 'NOTE_NOT_MARKDOWN' })
+
+    expect(sha256(absolutePath)).toBe(sha)
+  })
+
+  it('rejects a frontmatter edit on a PDF row', async () => {
+    const { absolutePath, sha } = await seedBinary('pdf-fm-1', 'scan.pdf', 'pdf', PDF_BYTES)
+
+    await expect(
+      notes.updateNote({ id: 'pdf-fm-1', frontmatter: { aliases: ['scan'] } })
+    ).rejects.toMatchObject({ code: 'NOTE_NOT_MARKDOWN' })
+
+    expect(sha256(absolutePath)).toBe(sha)
+  })
+
+  it('still lets a markdown note take a tag edit', async () => {
+    const created = await notes.createNote({ title: 'Meeting', content: 'Body.' })
+
+    const updated = await notes.updateNote({ id: created.id, tags: ['work'] })
+
+    expect(updated.tags).toEqual(['work'])
+    const raw = fs.readFileSync(path.join(tempVault.path, created.path), 'utf-8')
+    expect(raw).toContain('tags:')
+    expect(raw).toContain('- work')
+  })
+})

--- a/apps/desktop/src/main/vault/notes-crud.ts
+++ b/apps/desktop/src/main/vault/notes-crud.ts
@@ -64,7 +64,7 @@ import type { FolderInfo } from '@memry/contracts/templates-api'
 import { readFolderConfig } from './folders'
 import { createLogger } from '../lib/logger'
 import { trackMainLog } from '../telemetry/diagnostics'
-import { getFileType, getExtension } from '@memry/shared/file-types'
+import { getFileType, getExtension, isBinaryFileType } from '@memry/shared/file-types'
 import { getStatus, getConfig } from './index'
 import {
   emitNoteEvent,
@@ -605,6 +605,22 @@ export async function getNoteByPath(notePath: string): Promise<Note | null> {
 export async function updateNote(input: NoteUpdateInput): Promise<Note> {
   const db = getIndexDatabase()
   const dataDb = getDatabase()
+
+  // #2073: a PDF/image/audio/video row is binary content. Everything below
+  // reads the file as UTF-8, parses it as markdown and writes a serialized
+  // string back — on a PDF that replaces every non-ASCII byte with U+FFFD and
+  // prepends a YAML block, destroying the file. There is no durable home for a
+  // binary file's tags (`note_tags` is a rebuildable cache that `rebuildIndex`
+  // drops, and only markdown can restore itself from frontmatter), so the
+  // honest answer is to refuse rather than to accept and lose the bytes.
+  const cachedRow = getNoteCacheById(db, input.id)
+  if (cachedRow?.fileType && isBinaryFileType(cachedRow.fileType)) {
+    throw new NoteError(
+      `Cannot edit note metadata on a ${cachedRow.fileType} file: ${cachedRow.path}`,
+      NoteErrorCode.NOT_MARKDOWN,
+      input.id
+    )
+  }
 
   const existing = await getNoteById(input.id)
   if (!existing) {

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.test.tsx
@@ -942,3 +942,37 @@ describe('GroupedTable', () => {
     expect(onMoveToFolder).toHaveBeenCalledWith(['note-1', 'note-2'])
   })
 })
+
+// #2073: a folder holds PDFs and images next to notes. Their rows have no
+// frontmatter to write, and the tag write path used to overwrite the binary
+// with markdown, so the remove affordance must not be offered at all.
+describe('binary file rows (#2073)', () => {
+  const mixedNotes = [
+    { ...notes[0], tags: ['alpha'], fileType: 'markdown' },
+    { ...notes[1], id: 'pdf-1', title: 'Invoice.pdf', tags: ['billing'], fileType: 'pdf' }
+  ] as any[]
+
+  it.each([
+    ['FolderTableView', FolderTableView],
+    ['GroupedTable', GroupedTable]
+  ])('%s offers tag removal on the note row but not on the PDF row', (_name, Component) => {
+    const onTagRemove = vi.fn()
+
+    render(
+      <Component
+        notes={mixedNotes}
+        columns={columns}
+        formulas={{ double: 'score * 2' }}
+        propertyTypes={{ score: 'number' }}
+        onTagClick={vi.fn()}
+        onTagRemove={onTagRemove}
+      />
+    )
+
+    fireEvent.mouseEnter(screen.getByRole('option', { name: 'alpha' }))
+    expect(screen.getByRole('button', { name: 'removeAria alpha' })).toBeTruthy()
+
+    fireEvent.mouseEnter(screen.getByRole('option', { name: 'billing' }))
+    expect(screen.queryByRole('button', { name: 'removeAria billing' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx
@@ -94,6 +94,7 @@ import { RowContextMenu } from './row-context-menu'
 import { FolderViewEmptyState } from './folder-view-empty-state'
 import { SummaryRow } from './summary-row'
 import { SelectionCheckbox, SELECT_COLUMN_WIDTH, type SelectionState } from './selection-checkbox'
+import { isMetadataEditableRow } from './row-metadata-editability'
 
 /**
  * Sort order configuration (matches .folder.md format)
@@ -468,7 +469,7 @@ export function FolderTableView({
           tags={note.tags}
           onTagClick={onTagClick}
           onTagRemove={
-            onTagRemove
+            onTagRemove && isMetadataEditableRow(note)
               ? (tag) => {
                   onTagRemove(note.id, tag)
                 }
@@ -525,7 +526,7 @@ export function FolderTableView({
             type={type}
             highlightQuery={highlightQuery}
             onSave={
-              onPropertyUpdate
+              onPropertyUpdate && isMetadataEditableRow(note)
                 ? (nextValue) => {
                     onPropertyUpdate(note.id, columnId, nextValue)
                   }

--- a/apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx
@@ -101,6 +101,7 @@ import { RowContextMenu } from './row-context-menu'
 import { FolderViewEmptyState } from './folder-view-empty-state'
 import { SummaryRow } from './summary-row'
 import { SelectionCheckbox, SELECT_COLUMN_WIDTH, type SelectionState } from './selection-checkbox'
+import { isMetadataEditableRow } from './row-metadata-editability'
 
 // ============================================================================
 // Types
@@ -495,7 +496,7 @@ export function GroupedTable({
           tags={note.tags}
           onTagClick={onTagClick}
           onTagRemove={
-            onTagRemove
+            onTagRemove && isMetadataEditableRow(note)
               ? (tag) => {
                   onTagRemove(note.id, tag)
                 }
@@ -533,7 +534,7 @@ export function GroupedTable({
             type={type}
             highlightQuery={highlightQuery}
             onSave={
-              onPropertyUpdate
+              onPropertyUpdate && isMetadataEditableRow(note)
                 ? (nextValue) => {
                     onPropertyUpdate(note.id, columnId, nextValue)
                   }

--- a/apps/desktop/src/renderer/src/components/folder-view/row-metadata-editability.test.ts
+++ b/apps/desktop/src/renderer/src/components/folder-view/row-metadata-editability.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { isMetadataEditableRow } from './row-metadata-editability'
+
+describe('isMetadataEditableRow', () => {
+  it.each([
+    [{}, true],
+    [{ kind: 'note' as const }, true],
+    [{ kind: 'note' as const, fileType: 'markdown' as const }, true],
+    [{ fileType: 'pdf' as const }, false],
+    [{ fileType: 'image' as const }, false],
+    [{ fileType: 'audio' as const }, false],
+    [{ fileType: 'video' as const }, false],
+    [{ kind: 'task' as const }, false],
+    [{ kind: 'inbox' as const }, false],
+    [{ kind: 'note' as const, fileType: 'pdf' as const }, false]
+  ])('%o → %s', (row, expected) => {
+    expect(isMetadataEditableRow(row)).toBe(expected)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/folder-view/row-metadata-editability.ts
+++ b/apps/desktop/src/renderer/src/components/folder-view/row-metadata-editability.ts
@@ -1,0 +1,33 @@
+/**
+ * Which folder-view rows may have their Memry metadata edited in place.
+ *
+ * A folder holds PDFs, images, audio and video next to markdown notes, and the
+ * table renders them all. Only markdown carries frontmatter, so a tag or
+ * property write on any other row would run the file through the markdown
+ * serializer and replace its bytes with text (#2073). Those cells are rendered
+ * read-only instead — an affordance that reports success while destroying the
+ * file is worse than no affordance.
+ *
+ * @module components/folder-view/row-metadata-editability
+ */
+
+/**
+ * The parts of a folder-view row this decision needs. Structural on purpose:
+ * the page and the table components still speak the renderer-local
+ * `NoteWithProperties` while the IPC layer speaks the contracts one.
+ */
+interface MetadataEditableRow {
+  kind?: 'note' | 'task' | 'inbox'
+  fileType?: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
+}
+
+/**
+ * True when the row is a markdown note whose frontmatter can safely be written.
+ *
+ * `fileType` is absent on rows produced before the field existed; those are
+ * markdown notes, which is why the default is permissive.
+ */
+export function isMetadataEditableRow(row: MetadataEditableRow): boolean {
+  if ((row.kind ?? 'note') !== 'note') return false
+  return (row.fileType ?? 'markdown') === 'markdown'
+}

--- a/apps/desktop/src/renderer/src/hooks/use-folder-view.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-folder-view.ts
@@ -70,6 +70,12 @@ export interface NoteWithProperties {
   properties: Record<string, unknown>
   /** Row kind. Absent means 'note' — folder views only ever contain notes. */
   kind?: 'note' | 'task' | 'inbox'
+  /**
+   * What the row's file actually is. Only markdown carries frontmatter, so the
+   * tag and property cells stay read-only for anything else (#2073).
+   * Absent means 'markdown'.
+   */
+  fileType?: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
 }
 
 export interface AvailableProperty {

--- a/apps/desktop/src/renderer/src/pages/folder-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/folder-view.tsx
@@ -30,6 +30,7 @@ import { useOpenPage } from '@/hooks/use-open-target'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
 import { FolderTableView } from '@/components/folder-view/folder-table-view'
 import { GroupedTable } from '@/components/folder-view/grouped-table'
+import { isMetadataEditableRow } from '@/components/folder-view/row-metadata-editability'
 import { ColumnSelector } from '@/components/folder-view/column-selector'
 import { FilterBuilder } from '@/components/folder-view/filter-builder'
 import { GroupBySelector } from '@/components/folder-view/group-by-selector'
@@ -464,23 +465,46 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
   )
 
   // `updateNoteTags` goes to the notes-only `notesService.update` IPC, but the
-  // table wires this to every row's tag chips — and under tag scope a row can
-  // be a task or an inbox item. Gate on kind so a non-note id can never reach
-  // it. Ideally the chip's remove affordance wouldn't be offered on those rows
-  // at all, but the per-row `onTagRemove` closure lives in the table
-  // components; this is the last line before the IPC.
+  // table wires this to every row's tag chips — and a row can be a task, an
+  // inbox item, or a PDF/image filed in the folder. The cells no longer offer
+  // the remove affordance on those rows; this stays as the last line before
+  // the IPC, because reaching `updateNote` with a binary id used to overwrite
+  // the file with markdown (#2073).
   const handleTagRemove = useCallback(
     (noteId: string, tag: string): void => {
       const note = notes.find((n) => n.id === noteId)
       if (!note) return
-      if ((note.kind ?? 'note') !== 'note') {
-        log.warn('Ignoring tag removal on a non-note row', { id: noteId, kind: note.kind })
+      if (!isMetadataEditableRow(note)) {
+        log.warn('Ignoring tag removal on a row with no writable frontmatter', {
+          id: noteId,
+          kind: note.kind,
+          fileType: note.fileType
+        })
         return
       }
       const nextTags = note.tags.filter((t) => t !== tag)
       void updateNoteTags(noteId, nextTags)
     },
     [notes, updateNoteTags]
+  )
+
+  // Same gate for the property cells: `propertiesService.set` lands in the very
+  // same `updateNote` writer as a tag edit, so a PDF row must never reach it.
+  const handlePropertyUpdate = useCallback(
+    (noteId: string, propertyName: string, value: unknown): void => {
+      const note = notes.find((n) => n.id === noteId)
+      if (!note) return
+      if (!isMetadataEditableRow(note)) {
+        log.warn('Ignoring property update on a row with no writable frontmatter', {
+          id: noteId,
+          kind: note.kind,
+          fileType: note.fileType
+        })
+        return
+      }
+      void updateNoteProperty(noteId, propertyName, value)
+    },
+    [notes, updateNoteProperty]
   )
 
   // ============================================================================
@@ -892,6 +916,8 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
         selectedNoteIds.map((id) => {
           const note = notes.find((n) => n.id === id)
           if (!note || note.tags.includes(tag)) return Promise.resolve()
+          // A PDF/image row in a mixed selection has no frontmatter to write.
+          if (!isMetadataEditableRow(note)) return Promise.resolve()
           return updateNoteTags(id, [...note.tags, tag])
         })
       )
@@ -1226,7 +1252,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
               onTagRemove={handleTagRemove}
               onSetIcon={(...args) => void updateNoteIcon(...args)}
               tagMetaMap={tagMetaMap}
-              onPropertyUpdate={(...args) => void updateNoteProperty(...args)}
+              onPropertyUpdate={(...args) => void handlePropertyUpdate(...args)}
               onColumnsChange={(...args) => void updateColumns(...args)}
               onSortingChange={(...args) => void updateSorting(...args)}
               onDisplayNameChange={(...args) => void updateDisplayName(...args)}
@@ -1262,7 +1288,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
               onTagRemove={handleTagRemove}
               onSetIcon={(...args) => void updateNoteIcon(...args)}
               tagMetaMap={tagMetaMap}
-              onPropertyUpdate={(...args) => void updateNoteProperty(...args)}
+              onPropertyUpdate={(...args) => void handlePropertyUpdate(...args)}
               onColumnsChange={(...args) => void updateColumns(...args)}
               onSortingChange={(...args) => void updateSorting(...args)}
               onDisplayNameChange={(...args) => void updateDisplayName(...args)}

--- a/apps/desktop/tests/e2e/folder-view.e2e.ts
+++ b/apps/desktop/tests/e2e/folder-view.e2e.ts
@@ -138,6 +138,25 @@ function seedBulkNotes(vaultPath: string, folderPath: string, count: number): vo
   }
 }
 
+/**
+ * #2073: a real (tiny) PDF dropped into the folder. The table renders it as a
+ * row next to the notes, and the tag/property cells there used to run it
+ * through the markdown serializer and overwrite the bytes.
+ */
+const PDF_BYTES = Buffer.from(
+  '255044462d312e340a25e2e3cfd30a312030206f626a0a3c3c2f547970652f436174616c6f673e3e0a' +
+    '656e646f626a0a747261696c65720a3c3c2f526f6f742031203020523e3e0a2525454f460a',
+  'hex'
+)
+
+function seedPdf(vaultPath: string, folderPath: string, fileName: string): string {
+  const dir = path.join(vaultPath, 'notes', folderPath)
+  fs.mkdirSync(dir, { recursive: true })
+  const pdfPath = path.join(dir, fileName)
+  fs.writeFileSync(pdfPath, PDF_BYTES)
+  return pdfPath
+}
+
 function folderConfigPath(vaultPath: string, folderPath: string): string {
   return path.join(vaultPath, 'notes', folderPath, '.folder.md')
 }
@@ -680,5 +699,54 @@ test.describe('Folder View Performance', () => {
     } else {
       expect(true).toBe(true)
     }
+  })
+})
+
+// ============================================================================
+// #2073 — binary rows in the folder table
+// ============================================================================
+
+test.describe('Folder View — binary rows (#2073)', () => {
+  const PDF_NAME = 'invoice-2073.pdf'
+
+  test.beforeEach(async ({ page, testVaultPath }) => {
+    seedProjectNotes(testVaultPath)
+    seedPdf(testVaultPath, PROJECT_FOLDER, PDF_NAME)
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+    await navigateTo(page, 'notes')
+    await page.waitForTimeout(process.env.CI ? 2000 : 800)
+  })
+
+  test('a bulk tag add over a PDF row leaves the PDF byte-for-byte intact', async ({
+    page,
+    testVaultPath
+  }) => {
+    const pdfPath = path.join(testVaultPath, 'notes', PROJECT_FOLDER, PDF_NAME)
+    expect(fs.existsSync(pdfPath)).toBe(true)
+
+    await openFolderView(page, PROJECT_FOLDER, PROJECT_FOLDER)
+    await page.waitForTimeout(process.env.CI ? 1500 : 800)
+
+    // Select every row, PDF included, then push a tag through the bulk bar.
+    const selectAll = page.getByRole('checkbox', { name: 'Select all notes' }).first()
+    if (await selectAll.isVisible().catch(() => false)) {
+      await selectAll.click().catch(() => {})
+      await page.waitForTimeout(400)
+
+      const addTag = page.getByRole('button', { name: 'Add tag' }).first()
+      if (await addTag.isVisible().catch(() => false)) {
+        await addTag.click().catch(() => {})
+        const input = page.getByPlaceholder('Tag name').first()
+        if (await input.isVisible().catch(() => false)) {
+          await input.fill('audited').catch(() => {})
+          await page.keyboard.press('Enter').catch(() => {})
+          await page.waitForTimeout(process.env.CI ? 2000 : 1000)
+        }
+      }
+    }
+
+    // The invariant, regardless of how far the UI walk got: the PDF is untouched.
+    expect(Buffer.compare(fs.readFileSync(pdfPath), PDF_BYTES)).toBe(0)
   })
 })

--- a/apps/docs/src/user-guide/folder-view.md
+++ b/apps/docs/src/user-guide/folder-view.md
@@ -73,13 +73,17 @@ Click any editable cell to update a property in place. Supported types:
 
 Some fields (e.g. created date) are read-only.
 
+### PDFs, images, and other attachments
+
+A folder can hold PDFs, images, audio, and video alongside your notes, and they get their own rows in the table. Tags and properties live in a note's frontmatter, which only Markdown files have, so those cells are read-only on an attachment row: existing tags still display, but there is no remove control and the value cannot be edited. Renaming, moving, and opening an attachment work as usual.
+
 ## Bulk Operations
 
 Select rows with checkboxes for:
 
 - Move to folder
-- Add / remove tags
-- Set / clear properties (for editable types)
+- Add / remove tags (Markdown notes only)
+- Set / clear properties (for editable types, Markdown notes only)
 - Delete
 
 The bulk action bar appears at the top of the table when rows are selected.

--- a/packages/contracts/src/folder-view-api.ts
+++ b/packages/contracts/src/folder-view-api.ts
@@ -458,6 +458,19 @@ export interface NoteWithProperties {
 
   /** Row kind. Absent means 'note' — folder views only ever contain notes. */
   kind?: 'note' | 'task' | 'inbox'
+
+  /**
+   * What the row's file actually is. A folder contains PDFs, images, audio and
+   * video alongside markdown notes, and only markdown can carry frontmatter.
+   * Cells that write metadata must stay read-only for every other value —
+   * writing one would replace the binary's bytes with text (#2073).
+   * Absent means 'markdown' for rows that predate this field.
+   *
+   * Spelled out rather than imported from `NoteFileType` in `search-api`: this
+   * module is imported by the sync client, and the extra module edge drags
+   * `inbox-api` (and its Node `Buffer` types) into that build.
+   */
+  fileType?: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Editing a PDF's tags from the folder table view overwrote the PDF with markdown. Reported twice on `v2026-09-03.2` / Win32. Closes #2073.

**Proven mechanism.** The folder-table row query selects every `note_cache` row under the folder path with no `file_type` filter, and does not project `file_type` — so PDFs, images, audio and video get rows next to the notes and the renderer cannot tell them apart. Removing a tag chip on one of those rows calls `notes:update` → `updateNote`, which `safeRead`s the file as UTF-8, `parseNote`s it as markdown, re-serializes through the frontmatter writer and `atomicWrite`s the string back. On a PDF that is fatal twice over. A fixture PDF starting

```
25 50 44 46 2d 31 2e 34 0a 25 e2 e3 cf d3 ...     %PDF-1.4 %....
```

came back as

```
2d 2d 2d 0a 74 61 67 73 ...  25 50 44 46 2d 31 2e 34 0a 25 ef bf bd ef bf bd ...
---\ntags:\n  - invoice\n---\n%PDF-1.4\n%���� ...
```

Every non-ASCII byte became U+FFFD and a YAML block landed ahead of `%PDF`, shifting every byte offset. `properties:set` funnels into the same writer, so every editable property cell on that row had the same effect.

**Fix.** `updateNote` refuses any row whose `file_type` is not markdown, before it reads a byte — one chokepoint that covers both `notes:update` and `properties:set`. The folder-view row now carries `fileType`, and the tag and property cells render read-only on non-markdown rows (no remove control, no click-to-edit), matching how `relation` / `project` cells already behave in that table.

**Why refuse rather than persist.** I took the issue's second option deliberately. `note_tags` is a rebuildable cache — `rebuildIndex` deletes `index.db` outright, and only markdown can restore its tags from frontmatter, so a binary file's tags written there would vanish on the next rebuild with no source of truth. The durable store, `note_metadata`, has no tags column and is a synced row, so adding one is a schema plus sync-protocol change rather than the "smallest compatible seam". Writing user-authored tags into a cache and calling them persisted is the same class of silent data loss as the bug itself. Existing rows, tags, attachment references, sync and restart behaviour are untouched; tags already in `note_tags` for a binary row still display, they are just no longer editable.

**Assumptions / notes for review**

- All ten existing `updateNote` / `updateNoteCommand` callers are markdown-note operations (inbox filing, MCP write tools, templates, entity properties), so the throw cannot regress a legitimate flow. Binary rename already had its own guard and is unaffected.
- The read-only treatment is silent rather than tooltipped, consistent with the existing read-only cells in the same table. No new i18n strings.
- `fileType` is spelled out in `folder-view-api.ts` rather than imported from `NoteFileType` in `search-api.ts`: that module edge drags `inbox-api` and its Node `Buffer` types into the sync-client build and breaks `@memry/sync-client` typecheck.
- Pre-existing, not touched: `NoteWithProperties` is declared twice, once in `packages/contracts` and once in `use-folder-view.ts`. I added `fileType` to both and kept the new helper structural rather than picking a side.

## Release note

Editing the tags or properties of a PDF, image, audio, or video file from a folder table no longer corrupts the file. Those cells are now read-only for attachments, since only Markdown notes can store tags and properties.

## Test plan

- New `apps/desktop/src/main/vault/binary-metadata-safety.test.ts` — sha256 of a fixture PDF and PNG before/after a tag edit, a property edit and a frontmatter edit; each rejects with `NOTE_NOT_MARKDOWN` and leaves the bytes byte-for-byte identical. Markdown tag editing is asserted unchanged in the same suite. Confirmed to fail (hash mismatch) before the fix.
- New `row-metadata-editability.test.ts` — the note/task/inbox × markdown/pdf/image/audio/video matrix.
- `folder-table-view.test.tsx` — both `FolderTableView` and `GroupedTable` still offer tag removal on a note row and do not offer it on a PDF row.
- New E2E case in `folder-view.e2e.ts` — seeds a PDF into the folder, drives a bulk tag add over the selection, asserts the PDF bytes are unchanged. **Not verified locally:** the Electron E2E harness does not boot in this worktree, and a pre-existing untouched test (`T124`) times out in its `beforeEach` the same way, so this is environmental. Relying on CI for it.
- `pnpm lint`, `pnpm typecheck`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm ipc:generate && pnpm ipc:check` (no diff), `pnpm --filter @memry/desktop i18n:check`, `git diff --check` — all pass.
- `--project main src/main/vault src/main/ipc/folder-view-handlers.test.ts src/main/notes` — 940 passed.
- `--project renderer src/renderer/src/components/folder-view src/renderer/src/hooks` — 1144 passed.
- `pnpm docs:impact --base origin/main --strict` and `pnpm docs:build` pass; `apps/docs/src/user-guide/folder-view.md` documents the read-only attachment cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)