### PR TITLE
fix(desktop): keep the block when a bare URL is pasted

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -673,6 +673,9 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
       const block = editor.getTextCursorPosition()?.block
       if (!block) return
 
+      // Nothing to do: the editor's paste handler already inserted the URL as a
+      // plain inline link, leaving the block (list item, table cell, ...) and
+      // the surrounding text untouched. See `paste-url-link.ts`.
       if (option === 'url') return
 
       // The pasted URL sits in the block as either a link node or plain text

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-paste-link-menu.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-paste-link-menu.ts
@@ -1,7 +1,6 @@
 import { useCallback, useLayoutEffect, useState } from 'react'
 import { extractYouTubeVideoId } from '@/lib/youtube-utils'
-
-const URL_REGEX = /^https?:\/\/\S+$/
+import { readBareUrl } from '../paste-url-link'
 
 function detectEmbedProvider(url: string): string | null {
   if (extractYouTubeVideoId(url)) return 'youtube'
@@ -51,8 +50,8 @@ export function usePasteLinkMenu({ editorContainerRef, onSelect }: UsePasteLinkM
     const handlePaste = (e: ClipboardEvent): void => {
       if (state.isOpen) return
 
-      const text = e.clipboardData?.getData('text/plain')?.trim()
-      if (!text || !URL_REGEX.test(text)) return
+      const text = readBareUrl(e.clipboardData?.getData('text/plain'))
+      if (!text) return
 
       const options: PasteLinkOption[] = ['mention']
       if (detectEmbedProvider(text)) {

--- a/apps/desktop/src/renderer/src/components/note/content-area/paste-url-link.integration.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/paste-url-link.integration.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { BlockNoteEditor } from '@blocknote/core'
+import { TextSelection } from '@tiptap/pm/state'
+import { handleEditorPaste } from './table-cell-paste'
+
+// Issue #2081: "pasting a URL into a bulleted list and choosing URL removes the
+// bullet marker", and issue #2080: the pasted link has to stay ordinary,
+// editable inline content. Both live inside ProseMirror's paste pipeline, so
+// these run against a real mounted BlockNote editor and a real clipboard
+// payload — a mocked editor would report success either way.
+//
+// Uses the default BlockNote schema: it carries the list and table blocks, and
+// the custom schema's extra specs drag react-pdf into jsdom.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+class FakeDataTransfer {
+  private readonly store = new Map<string, string>()
+  readonly files: unknown[] = []
+
+  setData(type: string, value: string): void {
+    this.store.set(type, value)
+  }
+
+  getData(type: string): string {
+    return this.store.get(type) ?? ''
+  }
+
+  get types(): string[] {
+    return [...this.store.keys()]
+  }
+}
+
+beforeEach(() => {
+  if ((globalThis as any).ClipboardEvent) return
+  class StubClipboardEvent extends Event {
+    clipboardData = new FakeDataTransfer()
+  }
+  ;(globalThis as any).ClipboardEvent = StubClipboardEvent
+})
+
+const mounted: Array<{ editor: BlockNoteEditor; el: HTMLElement }> = []
+
+afterEach(() => {
+  for (const { editor, el } of mounted.splice(0)) {
+    editor.unmount()
+    el.remove()
+  }
+})
+
+const URL = 'https://example.com/a/b?c=1'
+
+function mountEditor(initialContent: any[]): BlockNoteEditor {
+  const editor = BlockNoteEditor.create({
+    pasteHandler: handleEditorPaste,
+    initialContent
+  }) as BlockNoteEditor
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  editor.mount(el)
+  mounted.push({ editor, el })
+  return editor
+}
+
+function view(editor: BlockNoteEditor): any {
+  return (editor as any).prosemirrorView
+}
+
+function findText(editor: BlockNoteEditor, needle: string): { from: number; to: number } {
+  let found: { from: number; to: number } | null = null
+  view(editor).state.doc.descendants((node: any, pos: number) => {
+    if (found || !node.isText || node.text !== needle) return
+    found = { from: pos, to: pos + needle.length }
+  })
+  if (!found) throw new Error(`no text node reads "${needle}"`)
+  return found
+}
+
+/** Put the caret between the two halves of a "beforeafter" run of text. */
+function placeCursorInside(editor: BlockNoteEditor, text: string, offset: number): void {
+  const { from } = findText(editor, text)
+  const v = view(editor)
+  v.dispatch(v.state.tr.setSelection(TextSelection.create(v.state.doc, from + offset)))
+}
+
+/**
+ * A browser puts both flavours on the clipboard when a link is copied from a
+ * page. The `text/html` one is what the default handler prefers for a bare URL
+ * (it carries no markdown syntax), and parsing that `<a>` yields a whole
+ * paragraph *block* — which is what used to replace the list item.
+ */
+function paste(editor: BlockNoteEditor, text: string, html?: string): void {
+  const data = new FakeDataTransfer()
+  data.setData('text/plain', text)
+  if (html !== undefined) data.setData('text/html', html)
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', { value: data })
+  view(editor).dom.dispatchEvent(event)
+}
+
+/** Flattens a block's inline content into `text` runs and `<link href>` markers. */
+function inlineShape(block: any): string {
+  return (block.content ?? [])
+    .map((inline: any) => (inline.type === 'link' ? `<link ${inline.href}>` : (inline.text ?? '')))
+    .join('')
+}
+
+/**
+ * BlockNote always keeps one trailing empty paragraph, so "the paste created no
+ * block of its own" means: nothing beyond the original blocks carries content.
+ */
+function extraBlockCount(editor: BlockNoteEditor, originalBlocks: number): number {
+  return (editor.document as any[])
+    .slice(originalBlocks)
+    .filter((block) => block.type !== 'paragraph' || (block.content ?? []).length > 0).length
+}
+
+function firstTableCell(editor: BlockNoteEditor): any {
+  const table = editor.document.find((b) => b.type === 'table') as any
+  return table.content.rows[1].cells[0]
+}
+
+describe('pasting a bare URL', () => {
+  it('keeps a bulleted list item a bulleted list item', () => {
+    const editor = mountEditor([{ type: 'bulletListItem', content: 'beforeafter' }])
+    placeCursorInside(editor, 'beforeafter', 'before'.length)
+
+    paste(editor, URL, `<a href="${URL}">${URL}</a>`)
+
+    const [block] = editor.document as any[]
+    expect(block.type).toBe('bulletListItem')
+    expect(inlineShape(block)).toBe(`before<link ${URL}>after`)
+    expect(extraBlockCount(editor, 1)).toBe(0)
+  })
+
+  it('keeps an empty bulleted list item a bulleted list item', () => {
+    const editor = mountEditor([
+      { type: 'bulletListItem', content: 'first' },
+      { type: 'bulletListItem', content: '' }
+    ])
+    editor.setTextCursorPosition((editor.document as any[])[1], 'end')
+
+    paste(editor, URL, `<a href="${URL}">${URL}</a>`)
+
+    const blocks = editor.document as any[]
+    expect(blocks[1].type).toBe('bulletListItem')
+    expect(inlineShape(blocks[1])).toBe(`<link ${URL}>`)
+  })
+
+  it('keeps a numbered list item numbered', () => {
+    const editor = mountEditor([{ type: 'numberedListItem', content: 'beforeafter' }])
+    placeCursorInside(editor, 'beforeafter', 'before'.length)
+
+    paste(editor, URL, `<a href="${URL}">${URL}</a>`)
+
+    const [block] = editor.document as any[]
+    expect(block.type).toBe('numberedListItem')
+    expect(inlineShape(block)).toBe(`before<link ${URL}>after`)
+  })
+
+  it('keeps a nested list item nested under its parent', () => {
+    const editor = mountEditor([
+      {
+        type: 'bulletListItem',
+        content: 'parent',
+        children: [{ type: 'bulletListItem', content: 'beforeafter' }]
+      }
+    ])
+    placeCursorInside(editor, 'beforeafter', 'before'.length)
+
+    paste(editor, URL, `<a href="${URL}">${URL}</a>`)
+
+    const [parent] = editor.document as any[]
+    expect(parent.type).toBe('bulletListItem')
+    expect(parent.children).toHaveLength(1)
+    const child = parent.children[0]
+    expect(child.type).toBe('bulletListItem')
+    expect(inlineShape(child)).toBe(`before<link ${URL}>after`)
+  })
+
+  it('keeps the rest of a table intact when pasted into a cell', () => {
+    const editor = mountEditor([
+      {
+        type: 'table',
+        content: {
+          type: 'tableContent',
+          headerRows: 1,
+          rows: [{ cells: ['Task', 'Owner'] }, { cells: ['beforeafter', 'Kaan'] }]
+        }
+      }
+    ])
+    placeCursorInside(editor, 'beforeafter', 'before'.length)
+
+    paste(editor, URL, `<a href="${URL}">${URL}</a>`)
+
+    const table = editor.document.find((b) => b.type === 'table') as any
+    expect(table.content.rows).toHaveLength(2)
+    expect(inlineShape(firstTableCell(editor))).toBe(`before<link ${URL}>after`)
+    expect(extraBlockCount(editor, 1)).toBe(0)
+  })
+
+  it('inserts one inline link into a paragraph rather than a new block', () => {
+    const editor = mountEditor([{ type: 'paragraph', content: 'beforeafter' }])
+    placeCursorInside(editor, 'beforeafter', 'before'.length)
+
+    paste(editor, URL, `<a href="${URL}">${URL}</a>`)
+
+    expect(extraBlockCount(editor, 1)).toBe(0)
+    const [block] = editor.document as any[]
+    expect(block.type).toBe('paragraph')
+    expect(inlineShape(block)).toBe(`before<link ${URL}>after`)
+    // Exactly one URL, no duplicated raw text next to the link.
+    expect((block.content as any[]).filter((i) => i.type === 'link')).toHaveLength(1)
+  })
+
+  it('leaves the pasted link as editable inline content', () => {
+    const editor = mountEditor([{ type: 'bulletListItem', content: 'beforeafter' }])
+    placeCursorInside(editor, 'beforeafter', 'before'.length)
+    paste(editor, URL, `<a href="${URL}">${URL}</a>`)
+
+    const link = (editor.document as any[])[0].content.find((i: any) => i.type === 'link')
+    // A link carries real text children, so the caret can sit inside it and a
+    // selection can cover part of it — it is not an atomic chip.
+    expect(link.content).toEqual([{ type: 'text', text: URL, styles: {} }])
+
+    // The caret sits after the link: typing continues the line, it does not
+    // replace or delete the link.
+    editor.insertInlineContent('!')
+    expect(inlineShape((editor.document as any[])[0])).toBe(`before<link ${URL}>!after`)
+  })
+
+  it('replaces the selected text instead of leaving it next to the link', () => {
+    const editor = mountEditor([{ type: 'bulletListItem', content: 'beforeoldafter' }])
+    const { from } = findText(editor, 'beforeoldafter')
+    const v = view(editor)
+    v.dispatch(
+      v.state.tr.setSelection(
+        TextSelection.create(v.state.doc, from + 'before'.length, from + 'beforeold'.length)
+      )
+    )
+
+    paste(editor, URL, `<a href="${URL}">${URL}</a>`)
+
+    const [block] = editor.document as any[]
+    expect(block.type).toBe('bulletListItem')
+    expect(inlineShape(block)).toBe(`before<link ${URL}>after`)
+  })
+
+  it('leaves plain text that is not a bare URL to the default handler', () => {
+    const editor = mountEditor([{ type: 'bulletListItem', content: 'beforeafter' }])
+    placeCursorInside(editor, 'beforeafter', 'before'.length)
+
+    paste(editor, 'see https://example.com for more')
+
+    const [block] = editor.document as any[]
+    expect(block.type).toBe('bulletListItem')
+    // The default handler's own autolinking, untouched by this fix.
+    expect(inlineShape(block)).toBe('beforesee <link https://example.com> for moreafter')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/paste-url-link.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/paste-url-link.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { BlockNoteEditor } from '@blocknote/core'
+
+/**
+ * A clipboard payload that is nothing but a single `http(s)` URL.
+ *
+ * This is the same predicate the paste-link menu keys off, so the menu and the
+ * editor's paste handler always agree on what counts as a "pasted URL".
+ */
+const BARE_URL_REGEX = /^https?:\/\/\S+$/
+
+/** The clipboard text as a bare URL, or `null` when it is anything else. */
+export function readBareUrl(text: string | null | undefined): string | null {
+  const trimmed = text?.trim()
+  if (!trimmed || !BARE_URL_REGEX.test(trimmed)) return null
+  return trimmed
+}
+
+/**
+ * BlockNote reads `text/plain` as markdown, so a bare URL comes back as a
+ * *paragraph block* and pasting it replaces the block the cursor sits in — a
+ * bulleted list item loses its bullet, a numbered item its number (issue
+ * #2081). Inserting the URL as inline content instead never touches the block:
+ * list items, nested list items and table cells keep their type and props, and
+ * the text before and after the cursor is preserved.
+ *
+ * The result is an ordinary inline `link`, not an atomic chip, so the caret can
+ * sit on either side of it and it can be selected, copied, edited and moved
+ * like any other text (issue #2080). It is also exactly the shape the Mention,
+ * Bookmark and Embed branches already look for (`type === 'link'` with a
+ * matching `href`), so those paths are unaffected.
+ */
+export function insertUrlAsLink(editor: BlockNoteEditor<any, any, any>, url: string): boolean {
+  try {
+    editor.insertInlineContent([{ type: 'link', href: url, content: url }])
+    return true
+  } catch {
+    // No editor view yet, or a selection that cannot hold inline content — let
+    // the default paste handler deal with it.
+    return false
+  }
+}

--- a/apps/desktop/src/renderer/src/components/note/content-area/table-cell-paste.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/table-cell-paste.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { BlockNoteEditor } from '@blocknote/core'
+import { insertUrlAsLink, readBareUrl } from './paste-url-link'
 
 /**
  * BlockNote reads `text/plain` off the clipboard as markdown. Everywhere else
@@ -40,6 +41,7 @@ export function isSelectionInTableCell(editor: BlockNoteEditor<any, any, any>): 
 
 interface PasteContext {
   editor: BlockNoteEditor<any, any, any>
+  event: ClipboardEvent
   defaultPasteHandler: (options?: {
     prioritizeMarkdownOverHTML?: boolean
     plainTextAsMarkdown?: boolean
@@ -48,8 +50,21 @@ interface PasteContext {
 
 export function handleEditorPaste({
   editor,
+  event,
   defaultPasteHandler
 }: PasteContext): boolean | undefined {
+  // A clipboard holding nothing but a URL becomes an inline link, wherever the
+  // cursor is. The default handler would read it as markdown and replace the
+  // block, dropping a list item's bullet or number. See `paste-url-link.ts`.
+  // A clipboard carrying files is an attachment paste even when its text
+  // flavour happens to read as a URL — leave those to the default handler.
+  const clipboard = event?.clipboardData
+  const url = clipboard?.files?.length ? null : readBareUrl(clipboard?.getData('text/plain'))
+  if (url && insertUrlAsLink(editor, url)) {
+    event.preventDefault()
+    return true
+  }
+
   if (!isSelectionInTableCell(editor)) return defaultPasteHandler()
 
   // Both flags gate a markdown reading of `text/plain`: the first sniffs the

--- a/apps/desktop/tests/e2e/editor-command-flows.e2e.ts
+++ b/apps/desktop/tests/e2e/editor-command-flows.e2e.ts
@@ -291,7 +291,9 @@ test.describe('Editor command flows E2E', () => {
       .toEqual({ type: 'bulletListItem', links: [url] })
 
     // The bullet is still rendered, not just present in the model.
-    await expect(page.locator(`${SELECTORS.noteEditor} li`).first()).toBeVisible()
+    await expect(
+      page.locator('.bn-block-content[data-content-type="bulletListItem"]').first()
+    ).toBeVisible()
 
     // The link is editable inline content: typing continues the same list item
     // instead of replacing or deleting the link.

--- a/apps/desktop/tests/e2e/editor-command-flows.e2e.ts
+++ b/apps/desktop/tests/e2e/editor-command-flows.e2e.ts
@@ -46,6 +46,16 @@ async function chooseSlashItem(
   await page.keyboard.press('Enter')
 }
 
+/** Replaces the document with one empty bulleted list item and puts the caret in it. */
+async function resetToEmptyBulletItem(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const editor = (window as any).__memryEditor
+    if (!editor) throw new Error('window.__memryEditor not exposed')
+    editor.replaceBlocks(editor.document, [{ type: 'bulletListItem', content: '' }])
+    editor.setTextCursorPosition(editor.document[0].id, 'end')
+  })
+}
+
 async function firstBlockHasBoldText(page: Page): Promise<boolean> {
   return page.evaluate(() => {
     const editor = (window as any).__memryEditor
@@ -245,5 +255,60 @@ test.describe('Editor command flows E2E', () => {
       ;(window as any).__memryResolveAiInvocation?.()
       await window.electron.ipcRenderer.invoke('ai-inline:stop-server')
     })
+  })
+
+  // Issue #2081: choosing "URL" used to replace the list item with a paragraph,
+  // so the bullet disappeared. Issue #2080: the pasted URL has to stay ordinary
+  // editable inline content.
+  test('keeps the bullet and an editable link when a URL is pasted into a list item', async ({
+    page
+  }) => {
+    const url = 'https://example.com/paste-target'
+    await createNote(page, uniqueLabel('Paste URL In List'))
+    await focusEditor(page)
+    await resetToEmptyBulletItem(page)
+
+    await pastePlainText(page, url)
+    await expect(page.locator('[data-paste-link-menu]')).toBeVisible()
+    // Menu order: Mention, Bookmark, URL — "URL" is always the last option.
+    await page.keyboard.press('ArrowUp')
+    await page.keyboard.press('Enter')
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const editor = (window as any).__memryEditor
+          if (!editor) throw new Error('window.__memryEditor not exposed')
+          const block = editor.document[0]
+          return {
+            type: block?.type,
+            links: (block?.content ?? [])
+              .filter((inline: any) => inline.type === 'link')
+              .map((inline: any) => inline.href)
+          }
+        })
+      )
+      .toEqual({ type: 'bulletListItem', links: [url] })
+
+    // The bullet is still rendered, not just present in the model.
+    await expect(page.locator(`${SELECTORS.noteEditor} li`).first()).toBeVisible()
+
+    // The link is editable inline content: typing continues the same list item
+    // instead of replacing or deleting the link.
+    await page.keyboard.type(' tail')
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const editor = (window as any).__memryEditor
+          const block = editor.document[0]
+          return {
+            type: block?.type,
+            text: (block?.content ?? [])
+              .map((inline: any) => (inline.type === 'link' ? `<link>` : (inline.text ?? '')))
+              .join('')
+          }
+        })
+      )
+      .toEqual({ type: 'bulletListItem', text: '<link> tail' })
   })
 })

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -367,6 +367,10 @@ Colours are stored by name, not as a fixed shade, so notes you coloured in an ea
 
 Pasting a URL offers four ways to keep it: plain **URL**, an inline **Mention** pill, an **Embed** (for a video the app recognises), or a **Bookmark** card.
 
+**URL** keeps the line you are on exactly as it was. Paste into a bulleted item and it stays a bulleted item, bullet and all; the same goes for a numbered item, an item nested under another, and a table cell. Whatever you had typed before and after the cursor is still there, with the link sitting between them.
+
+The link it leaves behind is ordinary text. You can put the cursor on either side of it, select part or all of it, copy it, retype it, delete it, or drag it to another line — the same as any other words in the note. It is saved as plain Markdown, so it reads the same way after a sync or in another editor.
+
 This works inside a table cell too. **Mention** replaces the pasted URL in that one cell and leaves the rest of the table alone. **Embed** and **Bookmark** are blocks in their own right and a cell holds text only, so they take the URL out of the cell and place the card after the whole table.
 
 ## Pasting into a Table Cell


### PR DESCRIPTION
## Summary

Pasting a bare URL into an empty bulleted list item dropped the bullet (#2081).

Root cause: BlockNote reads `text/plain` as Markdown, and prefers `text/html` when the plain text carries no Markdown syntax. Either way a bare URL comes back as a paragraph **block**, and pasting a block over an empty block replaces its type — the `bulletListItem` became a `paragraph`. The `url` branch in `ContentArea.tsx` returned without normalising anything, so nothing put the bullet back.

The editor's paste handler (`table-cell-paste.ts`, the single `pasteHandler`) now recognises a clipboard holding nothing but an `http(s)` URL and inserts it as **inline** content instead of letting the default handler parse blocks. The block is never touched, so bulleted, numbered, nested and table-cell contexts keep their type and props, and the text on both sides of the cursor survives. A clipboard carrying files is left to the default handler, so attachment pastes are unaffected.

**This also covers #2080.** The inserted node is an ordinary inline `link` with real text children — not an atomic chip, not a selection boundary — so the caret can sit on either side of it and it can be selected, copied, edited, deleted and moved like any other text. It serialises to plain Markdown, so it survives write-back and reload unchanged. #2080 can be closed with this PR.

Mention, Bookmark and Embed are unchanged: they already look for `type === 'link'` with a matching `href`, which is exactly the shape now inserted.

Assumptions:
- "Bare URL" is the same predicate the paste-link menu already used (`/^https?:\/\/\S+$/` on trimmed `text/plain`), now shared from `paste-url-link.ts` so the menu and the paste handler can never disagree.
- A bare URL becomes an inline link regardless of the other clipboard flavours. Choosing the *default* representation for pasted URLs is #2074 and is not touched here.

No schema, contract, IPC or on-disk format change — links were already inline content serialised as `[url](url)`, so notes written by older versions are unaffected.

## Release note

Pasting a link into a bulleted or numbered list no longer removes the bullet, and a pasted link can now be selected, copied and edited like ordinary text.

## Test plan

- New `apps/desktop/src/renderer/src/components/note/content-area/paste-url-link.integration.test.ts` — 9 cases against a real mounted BlockNote editor and a real clipboard payload: bulleted item, **empty** bulleted item (the reported repro), numbered item, nested item, table cell, paragraph, selection replacement, the link staying editable inline content, and non-URL text still going to the default handler. Verified red before the fix (`expected 'paragraph' to be 'bulletListItem'`), green after.
- New E2E case in `apps/desktop/tests/e2e/editor-command-flows.e2e.ts`: pastes a URL into a bulleted list item, chooses **URL**, asserts the block is still a `bulletListItem` with exactly one link, that an `li` is still rendered, and that typing afterwards extends the same list item.
- `pnpm lint`, `pnpm typecheck` (includes `check:contracts`, `check:architecture`, `ipc:check`), `git diff --check` — green.
- Renderer suite for the touched area: 74 files / 1091 tests passing.
- `pnpm docs:impact --base origin/main --strict` and `pnpm docs:build` — green.
- The E2E specs could not be run locally: every test in that file, including pre-existing ones, times out in the shared `ready(page)` `beforeEach` on this machine. Left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)