### PR TITLE
fix(desktop): open a journal reminder on its own date

### DIFF
--- a/apps/desktop/src/renderer/src/components/inbox-detail/reminder-detail.test.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/reminder-detail.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   markViewed: vi.fn(() => Promise.resolve()),
   archive: vi.fn(() => Promise.resolve({ success: true })),
   toastSuccess: vi.fn(),
+  toastError: vi.fn(),
   invalidateQueries: vi.fn()
 }))
 
@@ -16,7 +17,7 @@ vi.mock('@memry/i18n/renderer', () => ({
 }))
 
 vi.mock('sonner', () => ({
-  toast: { success: mocks.toastSuccess, info: vi.fn() }
+  toast: { success: mocks.toastSuccess, info: vi.fn(), error: mocks.toastError }
 }))
 
 vi.mock('@/contexts/tabs', () => ({
@@ -51,7 +52,7 @@ vi.mock('@/components/snooze/snooze-presets', () => ({
 }))
 
 vi.mock('@/lib/logger', () => ({
-  createLogger: () => ({ error: vi.fn(), debug: vi.fn() })
+  createLogger: () => ({ error: vi.fn(), debug: vi.fn(), warn: vi.fn() })
 }))
 
 const taskItem = {
@@ -111,5 +112,53 @@ describe('ReminderDetail task navigation', () => {
       expect.stringContaining('Archived'),
       expect.objectContaining({ action: expect.objectContaining({ label: 'Undo' }) })
     )
+  })
+})
+
+const journalItem = (targetId: string) => ({
+  id: 'inbox_rem_2',
+  type: 'reminder' as const,
+  title: 'Journal prompt',
+  content: null,
+  viewedAt: null,
+  metadata: {
+    reminderId: 'rem-2',
+    targetType: 'journal' as const,
+    targetId,
+    targetTitle: targetId,
+    remindAt: '2026-05-10T09:00:00.000Z'
+  }
+})
+
+describe('ReminderDetail journal navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("opens the reminder's own journal date, not today (#2071)", () => {
+    render(<ReminderDetail item={journalItem('2026-05-10') as never} />)
+
+    fireEvent.click(
+      screen.getByText('reminder.journalTitle').closest('button') as HTMLButtonElement
+    )
+
+    expect(mocks.openTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'journal',
+        path: '/journal',
+        viewState: { date: '2026-05-10' }
+      })
+    )
+  })
+
+  it('opens nothing and reports when the stored journal date is unusable', () => {
+    render(<ReminderDetail item={journalItem('2026-02-31') as never} />)
+
+    fireEvent.click(
+      screen.getByText('reminder.journalTitle').closest('button') as HTMLButtonElement
+    )
+
+    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('reminder.dataUnavailable')
   })
 })

--- a/apps/desktop/src/renderer/src/components/inbox-detail/reminder-detail.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/reminder-detail.tsx
@@ -11,6 +11,7 @@ import { inboxService } from '@/services/inbox-service'
 import { inboxKeys } from '@/hooks/use-inbox'
 import { useUndoableAction } from '@/hooks/use-undoable-action'
 import { useTabs } from '@/contexts/tabs'
+import { toast } from 'sonner'
 import { createLogger } from '@/lib/logger'
 import { buildReminderTargetTab } from '@/lib/open-reminder-target'
 import type { InboxItem, InboxItemListItem } from '@/types'
@@ -104,23 +105,31 @@ export function ReminderDetail({ item }: ReminderDetailProps): React.JSX.Element
 
     inboxService.markViewed(item.id).catch((err) => log.warn('Failed to mark reminder viewed', err))
 
-    openTab(
-      buildReminderTargetTab({
-        targetType: metadata.targetType,
-        targetId: metadata.targetId,
-        targetTitle: metadata.targetTitle,
-        projectId: metadata.projectId,
-        anchorId: metadata.anchorId,
-        highlightStart: metadata.highlightStart,
-        highlightEnd: metadata.highlightEnd,
-        highlightText: metadata.highlightText,
-        fallbacks: {
-          note: t('reminder.noteFallback'),
-          journal: t('reminder.journalFallback'),
-          task: t('reminder.taskFallback')
-        }
-      })
-    )
+    const tab = buildReminderTargetTab({
+      targetType: metadata.targetType,
+      targetId: metadata.targetId,
+      targetTitle: metadata.targetTitle,
+      projectId: metadata.projectId,
+      anchorId: metadata.anchorId,
+      highlightStart: metadata.highlightStart,
+      highlightEnd: metadata.highlightEnd,
+      highlightText: metadata.highlightText,
+      fallbacks: {
+        note: t('reminder.noteFallback'),
+        journal: t('reminder.journalFallback'),
+        task: t('reminder.taskFallback')
+      }
+    })
+
+    // A journal reminder whose stored date is unusable has no day to open.
+    // Say so rather than dropping the user on today's entry.
+    if (!tab) {
+      log.warn(`Reminder ${item.id} has an unusable target: ${metadata.targetId}`)
+      toast.error(t('reminder.dataUnavailable'))
+      return
+    }
+
+    openTab(tab)
   }, [metadata, item.id, openTab, t])
 
   if (!metadata) {

--- a/apps/desktop/src/renderer/src/components/medium-cold-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/medium-cold-surfaces.test.tsx
@@ -42,6 +42,7 @@ vi.mock('sonner', () => ({
 vi.mock('@/lib/logger', () => ({
   createLogger: () => ({
     info: vi.fn(),
+    warn: vi.fn(),
     error: vi.fn()
   })
 }))
@@ -397,15 +398,52 @@ describe('medium cold renderer surfaces', () => {
     )
     expect(dismissMutate).toHaveBeenCalledWith('rem-1')
 
+    // #2071: the OS-notification click opens the reminder's OWN day. The date
+    // must ride `viewState.date` — the journal page reads it there and nowhere
+    // else — and the tab must keep the singleton `/journal` path so an already
+    // open journal tab is moved to that day instead of staying on today.
     act(() => {
       clickCallbacks[0]({ reminder: reminders[1] })
     })
     expect(openTab).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'journal',
-        path: '/journal?date=2026-05-10'
+        path: '/journal',
+        viewState: { date: '2026-05-10' }
       })
     )
+
+    // The in-app toast's "View" is the same navigation, not a second one.
+    openTab.mockClear()
+    toastMock.base.mock.calls[1][1].action.onClick()
+    expect(openTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'journal',
+        path: '/journal',
+        viewState: { date: '2026-05-10' }
+      })
+    )
+
+    // A note reminder still opens its note tab, unchanged.
+    openTab.mockClear()
+    act(() => {
+      clickCallbacks[0]({ reminder: reminders[2] })
+    })
+    expect(openTab).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'note', path: '/notes/note-3', entityId: 'note-3' })
+    )
+
+    // A journal target that is not a real day opens nothing at all, rather than
+    // falling through to today's entry.
+    openTab.mockClear()
+    toastMock.error.mockClear()
+    act(() => {
+      clickCallbacks[0]({
+        reminder: { id: 'rem-7', title: 'Broken', targetType: 'journal', targetId: '2026-02-31' }
+      })
+    })
+    expect(openTab).not.toHaveBeenCalled()
+    expect(toastMock.error).toHaveBeenCalledWith('reminder.dataUnavailable')
 
     unmount()
     expect(unsubDue).toHaveBeenCalled()

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.test.ts
@@ -74,6 +74,51 @@ describe('tabCrudReducer', () => {
     vi.unstubAllGlobals()
   })
 
+  it('carries viewState onto a singleton focused in another group', () => {
+    // #2071: a journal tab opened from the command palette lives at
+    // `/journal/<date>` with an entityId, so a reminder's `/journal` open misses
+    // both path-keyed dedup branches and lands here. Dropping the incoming
+    // viewState left that tab on the day it already showed — today — instead of
+    // the reminder's date.
+    const state = baseState({
+      tabGroups: {
+        g1: group('g1', [tab('tasks', 'tasks', { path: '/tasks' })]),
+        g2: group('g2', [
+          tab('journal', 'journal', {
+            path: '/journal/2026-05-10',
+            entityId: '2026-05-10',
+            viewState: { date: '2026-05-10' }
+          })
+        ])
+      }
+    })
+
+    const next = tabCrudReducer(
+      state,
+      openAction({
+        tab: {
+          type: 'journal',
+          title: 'Journal',
+          icon: 'book-open',
+          path: '/journal',
+          isPinned: false,
+          isModified: false,
+          isPreview: false,
+          isDeleted: false,
+          viewState: { date: '2026-03-02' }
+        }
+      })
+    )
+
+    const focused = next.tabGroups.g2.tabs.find((t) => t.id === 'journal')
+    expect(focused?.viewState).toEqual({ date: '2026-03-02' })
+    expect(next.tabGroups.g2.activeTabId).toBe('journal')
+    expect(next.activeGroupId).toBe('g2')
+    // Focused, never cloned.
+    expect(next.tabGroups.g1.tabs).toHaveLength(1)
+    expect(next.tabGroups.g2.tabs).toHaveLength(1)
+  })
+
   it('opens tabs through replace, singleton, entity, insertion, and background paths', () => {
     const state = baseState()
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
@@ -189,7 +189,11 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
         }
       }
 
-      // Cross-group singleton focus: when no explicit groupId, find singleton anywhere
+      // Cross-group singleton focus: when no explicit groupId, find singleton
+      // anywhere. The incoming `viewState` is merged in, exactly as both dedup
+      // branches around this one do: a singleton open carries WHICH day/item to
+      // show (the journal's `date`, the calendar's `focusDate`), so focusing the
+      // existing tab without it silently lands the user on today.
       if (
         !forceNew &&
         SINGLETON_TAB_TYPES.includes(tab.type) &&
@@ -200,7 +204,14 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
         if (existing) {
           const existingGroup = state.tabGroups[existing.groupId]
           const updatedTabs = existingGroup.tabs.map((t) =>
-            t.id === existing.tab.id ? { ...t, isPreview: false, lastAccessedAt: Date.now() } : t
+            t.id === existing.tab.id
+              ? {
+                  ...t,
+                  isPreview: false,
+                  lastAccessedAt: Date.now(),
+                  ...(tab.viewState && { viewState: { ...t.viewState, ...tab.viewState } })
+                }
+              : t
           )
           const groupAfter = background
             ? { ...existingGroup, tabs: updatedTabs }

--- a/apps/desktop/src/renderer/src/hooks/use-reminder-notifications.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-reminder-notifications.ts
@@ -16,6 +16,7 @@ import { toast } from 'sonner'
 import { useTabs } from '@/contexts/tabs'
 import { useT } from '@memry/i18n/renderer'
 import { useDismissReminder } from '@/hooks/use-reminders'
+import { buildReminderTargetTab } from '@/lib/open-reminder-target'
 import type { ReminderWithTarget } from '@/services/reminder-service'
 
 const log = createLogger('Hook:ReminderNotifications')
@@ -44,59 +45,49 @@ interface ReminderClickedEvent {
 export function useReminderNotifications(): void {
   const { openTab } = useTabs()
   const { t } = useT('common')
+  // The reminder target fallbacks live in the inbox namespace, beside the other
+  // reminder strings the detail panel and the reminder list already use.
+  const { t: inboxT } = useT('inbox')
   const dismissMutation = useDismissReminder()
 
-  // Navigate to reminder target
+  // Navigate to reminder target.
+  //
+  // Deliberately the SAME builder the inbox reminder detail and the reminder
+  // list use. This path used to carry its own switch, which opened a journal as
+  // `path: '/journal?date=<date>'` with no `viewState` — the journal page reads
+  // the day off `viewState.date` and ignores the query, and the singleton-tab
+  // dedup matches on `path`, so clicking a due journal reminder focused the
+  // open journal tab and left it on today (#2071). It also had no `task` case
+  // at all, so a due task reminder's "View" did nothing.
   const navigateToTarget = useCallback(
     (reminder: ReminderWithTarget) => {
-      switch (reminder.targetType) {
-        case 'note':
-        case 'highlight':
-          openTab({
-            type: 'note',
-            title: reminder.targetTitle || 'Note',
-            icon: 'file-text',
-            path: `/notes/${reminder.targetId}`,
-            entityId: reminder.targetId,
-            isPinned: false,
-            isModified: false,
-            isPreview: false,
-            isDeleted: false
-          })
-          break
+      const tab = buildReminderTargetTab({
+        targetType: reminder.targetType,
+        targetId: reminder.targetId,
+        targetTitle: reminder.targetTitle,
+        projectId: reminder.projectId ?? undefined,
+        anchorId: reminder.anchorId ?? undefined,
+        highlightStart: reminder.highlightStart ?? undefined,
+        highlightEnd: reminder.highlightEnd ?? undefined,
+        highlightText: reminder.highlightText ?? undefined,
+        fallbacks: {
+          note: inboxT('reminder.noteFallback'),
+          journal: inboxT('reminder.journalFallback'),
+          task: inboxT('reminder.taskFallback')
+        }
+      })
 
-        case 'journal':
-          openTab({
-            type: 'journal',
-            title: `Journal - ${reminder.targetId}`,
-            icon: 'book-open',
-            path: `/journal?date=${reminder.targetId}`,
-            isPinned: false,
-            isModified: false,
-            isPreview: false,
-            isDeleted: false
-          })
-          break
-
-        case 'note_date':
-          // Inline date pill reminder: open the note and scroll to the pill via
-          // its stable anchor id (note.tsx reads viewState.anchorId).
-          openTab({
-            type: 'note',
-            title: reminder.targetTitle || 'Note',
-            icon: 'file-text',
-            path: `/notes/${reminder.targetId}`,
-            entityId: reminder.targetId,
-            isPinned: false,
-            isModified: false,
-            isPreview: false,
-            isDeleted: false,
-            viewState: { anchorId: reminder.anchorId ?? undefined }
-          })
-          break
+      // A journal reminder whose stored date is unusable has no day to open.
+      // Say so rather than dropping the user on today's entry.
+      if (!tab) {
+        log.warn(`Reminder ${reminder.id} has an unusable target: ${reminder.targetId}`)
+        toast.error(inboxT('reminder.dataUnavailable'))
+        return
       }
+
+      openTab(tab)
     },
-    [openTab]
+    [openTab, inboxT]
   )
 
   // Show toast notification for a reminder

--- a/apps/desktop/src/renderer/src/lib/open-reminder-target.test.ts
+++ b/apps/desktop/src/renderer/src/lib/open-reminder-target.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { buildReminderTargetTab } from './open-reminder-target'
+import { buildReminderTargetTab, isJournalDateId } from './open-reminder-target'
 
 const fallbacks = { note: 'Untitled note', journal: 'Journal', task: 'Task' }
 
@@ -23,7 +23,7 @@ describe('buildReminderTargetTab', () => {
       isPreview: false,
       isDeleted: false
     })
-    expect(tab.viewState).toBeUndefined()
+    expect(tab?.viewState).toBeUndefined()
   })
 
   it('falls back to the note fallback title when target title is null', () => {
@@ -34,7 +34,7 @@ describe('buildReminderTargetTab', () => {
       fallbacks
     })
 
-    expect(tab.title).toBe('Untitled note')
+    expect(tab?.title).toBe('Untitled note')
   })
 
   it('builds a note tab with highlight view state for highlight targets', () => {
@@ -48,9 +48,9 @@ describe('buildReminderTargetTab', () => {
       fallbacks
     })
 
-    expect(tab.type).toBe('note')
-    expect(tab.path).toBe('/notes/note-3')
-    expect(tab.viewState).toEqual({
+    expect(tab?.type).toBe('note')
+    expect(tab?.path).toBe('/notes/note-3')
+    expect(tab?.viewState).toEqual({
       highlightStart: 10,
       highlightEnd: 25,
       highlightText: 'important bit'
@@ -70,7 +70,7 @@ describe('buildReminderTargetTab', () => {
       path: '/journal',
       title: 'Journal'
     })
-    expect(tab.viewState).toEqual({ date: '2026-06-12' })
+    expect(tab?.viewState).toEqual({ date: '2026-06-12' })
   })
 
   it('builds a tasks tab that opens the task and its project', () => {
@@ -87,9 +87,31 @@ describe('buildReminderTargetTab', () => {
       path: '/tasks',
       title: 'Ship release notes'
     })
-    expect(tab.viewState).toMatchObject({
+    expect(tab?.viewState).toMatchObject({
       openTaskId: 'task-9',
       selectedProjectId: 'project-7'
     })
+  })
+})
+
+describe('isJournalDateId', () => {
+  it('accepts real calendar days', () => {
+    expect(isJournalDateId('2026-01-01')).toBe(true)
+    expect(isJournalDateId('2024-02-29')).toBe(true)
+    expect(isJournalDateId('2026-12-31')).toBe(true)
+  })
+
+  it('rejects a well-shaped string that is not a real day', () => {
+    // `new Date('2026-02-31')` rolls forward to March — exactly the "opens an
+    // unrelated date" failure the guard exists to stop.
+    expect(isJournalDateId('2026-02-31')).toBe(false)
+    expect(isJournalDateId('2026-13-01')).toBe(false)
+    expect(isJournalDateId('2026-00-10')).toBe(false)
+  })
+
+  it('rejects anything that is not a YYYY-MM-DD string', () => {
+    expect(isJournalDateId('')).toBe(false)
+    expect(isJournalDateId('2026-6-1')).toBe(false)
+    expect(isJournalDateId('note-1')).toBe(false)
   })
 })

--- a/apps/desktop/src/renderer/src/lib/open-reminder-target.ts
+++ b/apps/desktop/src/renderer/src/lib/open-reminder-target.ts
@@ -22,6 +22,31 @@ export interface ReminderTargetInput {
   fallbacks: { note: string; journal: string; task: string }
 }
 
+const JOURNAL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Is this reminder's `targetId` a journal day this app can open?
+ *
+ * A journal reminder is addressed by its local `YYYY-MM-DD` date — that string
+ * IS the navigation target, so a value that is not one has no day to open. The
+ * shape check is not enough on its own: `2026-02-31` matches the pattern and
+ * then rolls forward to March 3rd, which is exactly the "lands on an unrelated
+ * date" failure this guard exists to prevent, so the parts are compared back
+ * against a real date. Built in UTC deliberately — the check is about the
+ * calendar, not about an instant, and a local-midnight construction would make
+ * the answer depend on the reader's offset.
+ */
+export function isJournalDateId(targetId: string): boolean {
+  if (!JOURNAL_DATE_PATTERN.test(targetId)) return false
+  const [year, month, day] = targetId.split('-').map(Number)
+  const parsed = new Date(Date.UTC(year, month - 1, day))
+  return (
+    parsed.getUTCFullYear() === year &&
+    parsed.getUTCMonth() === month - 1 &&
+    parsed.getUTCDate() === day
+  )
+}
+
 const BASE_STATE = {
   isPinned: false,
   isModified: false,
@@ -32,14 +57,24 @@ const BASE_STATE = {
 /**
  * Map a reminder target to the tab descriptor that opens its source.
  *
- * Shared by the inbox reminder detail and the upcoming/past reminders list
- * so navigation stays identical across both surfaces.
+ * Shared by the inbox reminder detail, the upcoming/past reminders list and
+ * the due-reminder toast / OS notification click, so navigation stays identical
+ * across every surface a reminder can be clicked from.
+ *
+ * Returns null when the target cannot be turned into a destination — today that
+ * is only a journal reminder whose `targetId` is not a real calendar day. The
+ * caller reports it instead of opening some other date.
  */
-export function buildReminderTargetTab(input: ReminderTargetInput): ReminderTargetTab {
+export function buildReminderTargetTab(input: ReminderTargetInput): ReminderTargetTab | null {
   const { targetType, targetId, targetTitle, projectId, fallbacks } = input
 
   switch (targetType) {
     case 'journal':
+      // The stored date is the source of truth, never "today": `viewState.date`
+      // is what `pages/journal.tsx` reads to pick the day, and the tab keeps the
+      // journal's singleton path so an already-open journal tab is moved to that
+      // day rather than duplicated.
+      if (!isJournalDateId(targetId)) return null
       return {
         type: 'journal',
         title: fallbacks.journal,

--- a/apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx
@@ -43,6 +43,9 @@ import { notesKeys } from '@/hooks/use-notes-query'
 import { useInboxKeyboard } from '@/hooks/use-inbox-keyboard'
 import type { FilingTarget, ImageFilingMode } from '@memry/domain-inbox'
 import { toast } from 'sonner'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('Page:InboxListView')
 
 const ALLOWED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml']
 
@@ -434,23 +437,31 @@ export function InboxListView({
         void inboxService.markViewed(entry.inboxItemId)
       }
 
-      openTab(
-        buildReminderTargetTab({
-          targetType: entry.nav.targetType,
-          targetId: entry.nav.targetId,
-          targetTitle: entry.nav.targetTitle,
-          projectId: entry.nav.projectId,
-          anchorId: entry.nav.anchorId,
-          highlightStart: entry.nav.highlightStart,
-          highlightEnd: entry.nav.highlightEnd,
-          highlightText: entry.nav.highlightText,
-          fallbacks: {
-            note: t('reminder.noteFallback'),
-            journal: t('reminder.journalFallback'),
-            task: t('reminder.taskFallback')
-          }
-        })
-      )
+      const tab = buildReminderTargetTab({
+        targetType: entry.nav.targetType,
+        targetId: entry.nav.targetId,
+        targetTitle: entry.nav.targetTitle,
+        projectId: entry.nav.projectId,
+        anchorId: entry.nav.anchorId,
+        highlightStart: entry.nav.highlightStart,
+        highlightEnd: entry.nav.highlightEnd,
+        highlightText: entry.nav.highlightText,
+        fallbacks: {
+          note: t('reminder.noteFallback'),
+          journal: t('reminder.journalFallback'),
+          task: t('reminder.taskFallback')
+        }
+      })
+
+      // A journal reminder whose stored date is unusable has no day to open.
+      // Say so rather than dropping the user on today's entry.
+      if (!tab) {
+        log.warn(`Reminder target is unusable: ${entry.nav.targetType} ${entry.nav.targetId}`)
+        toast.error(t('reminder.dataUnavailable'))
+        return
+      }
+
+      openTab(tab)
     },
     [openTab, t, setActiveDetailItemId]
   )

--- a/apps/desktop/tests/e2e/journal-reminder-navigation.e2e.ts
+++ b/apps/desktop/tests/e2e/journal-reminder-navigation.e2e.ts
@@ -1,0 +1,76 @@
+/**
+ * Clicking a journal reminder must open the day the reminder stores, not today
+ * (#2071). The desktop-notification click is the path that was broken, so this
+ * drives that exact IPC event and then proves the destination by TYPING into the
+ * journal the app landed on: the text has to end up in the target day's file in
+ * the vault, and today's file must not have it.
+ *
+ * The vault file is the assertion on purpose — it is the app's own answer about
+ * which entry was open, rather than a rendered date string that could be right
+ * for the wrong reason.
+ */
+
+import { test, expect } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+import { navigateTo } from './utils/electron-helpers'
+import * as fs from 'fs'
+import * as path from 'path'
+
+test.describe('journal reminder navigation', () => {
+  test('a due journal reminder opens its own date, not today', async ({
+    page,
+    electronApp,
+    testVaultPath
+  }) => {
+    await ready(page)
+    await navigateTo(page, 'journal')
+
+    // Both dates are computed in the renderer so they are the same local days
+    // the app resolves — a UTC-derived key is a different day for half the world.
+    const { targetDate, today } = await page.evaluate(() => {
+      const key = (date: Date): string =>
+        `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(
+          date.getDate()
+        ).padStart(2, '0')}`
+      const past = new Date()
+      past.setDate(past.getDate() - 40)
+      return { targetDate: key(past), today: key(new Date()) }
+    })
+
+    const reminder = await page.evaluate(async (date) => {
+      await window.api.reminders.create({
+        targetType: 'journal',
+        targetId: date,
+        remindAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        title: 'Revisit this day'
+      })
+      const listed = await window.api.reminders.list({ targetType: 'journal', targetId: date })
+      return listed.reminders[0]
+    }, targetDate)
+
+    expect(reminder.targetId).toBe(targetDate)
+
+    // The OS notification click, as the main process delivers it.
+    await electronApp.evaluate(
+      ({ BrowserWindow }, payload) => {
+        BrowserWindow.getAllWindows()[0].webContents.send('reminder:clicked', payload)
+      },
+      { reminder: { ...reminder, targetTitle: targetDate, targetExists: true } }
+    )
+
+    const editor = page.locator('.bn-container [contenteditable="true"]').first()
+    await editor.waitFor({ state: 'visible', timeout: 15_000 })
+    await editor.click()
+    await page.keyboard.type('Reminder navigation landed here.')
+
+    const read = (date: string): string => {
+      const file = path.join(testVaultPath, 'journal', `${date}.md`)
+      return fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : ''
+    }
+
+    await expect
+      .poll(() => read(targetDate), { timeout: 20_000 })
+      .toContain('Reminder navigation landed here.')
+    expect(read(today)).not.toContain('Reminder navigation landed here.')
+  })
+})

--- a/apps/docs/src/user-guide/snooze-reminders.md
+++ b/apps/docs/src/user-guide/snooze-reminders.md
@@ -65,6 +65,8 @@ memrynote shows a toast with:
 - Title and snippet
 - Action buttons (snooze 5 min, snooze 10 min, custom snooze, open, dismiss)
 
+Opening a reminder — from the toast, from the system notification, or from a row in the inbox reminders view — always lands on the reminder's own source: the note, the note's date pill, the highlight, the task with its project, or the **journal day the reminder was set for**, never today's entry. If a journal reminder's stored date is unreadable, memrynote tells you instead of opening a different day.
+
 A system notification is shown as well. Dismissing, snoozing, or deleting the reminder also retires its system notification — on macOS it is removed from Notification Center, and on Windows and Linux the banner is closed — so handled reminders don't pile up. "Dismiss all" does the same for every reminder in the batch, and only for those: a reminder that wasn't part of the action keeps its notification. If a snoozed reminder comes due again, its new notification replaces the earlier one for that reminder instead of stacking a second banner. Notifications you haven't acted on are never dismissed for you.
 
 Dismissing a reminder updates every place it appears right away — the inbox reminders view, the note's reminder pill, the journal badge, the task chip, and any other open memrynote window. "Dismiss all" behaves the same way, refreshing those views once per reminder it actually dismissed.


### PR DESCRIPTION
## Summary

Closes #2071.

A journal reminder shows the right date but used to open Today Journal. Root cause, and it is not where the date is stored — the date was fine all along:

- **The due-reminder toast and the OS-notification click carried their own navigation switch.** It opened a journal as `path: '/journal?date=<date>'` with no `viewState`. `pages/journal.tsx` reads the day off `viewState.date` and nowhere else, so a fresh tab opened on today; and the singleton dedup in `OPEN_TAB` matches on `path`, so with a journal tab already open the click just focused it and left it where it was. That switch also had no `task` case at all, so a due task reminder's "View" did nothing. It is deleted: this path now uses `buildReminderTargetTab`, the builder the inbox reminder detail and the inbox reminders list already share, so every surface a reminder can be clicked from navigates identically. Per the note in #2156, no third journal-opening path was added.
- **`OPEN_TAB`'s cross-group singleton focus dropped the incoming `viewState`.** Both dedup branches around it merge it; this one did not. A journal tab opened from the command palette lives at `/journal/<date>` with an `entityId`, so a reminder's `/journal` open misses the path-keyed branches and lands in this one — which focused that tab and left it on the day it already showed. That is the second half of the bug, and the one that also hits the Inbox/reminder-list path. Merging `viewState` here matches the two neighbouring branches and fixes the same class of drop for the calendar's `focusDate`.
- **Malformed journal targets.** `buildReminderTargetTab` now returns `null` for a journal `targetId` that is not a real calendar day, and each caller reports it instead of navigating. The shape check alone is not enough: `2026-02-31` matches `YYYY-MM-DD` and then rolls forward to March 3rd, which is exactly the "unrelated date" failure. The day is validated in UTC on purpose — the question is about the calendar, not an instant, so the answer must not depend on the reader's offset.

Click paths traced and covered: the due toast's "View", the OS notification callback (`reminder:clicked`), the inbox reminders list row, and the inbox reminder detail's source button. Note, highlight, `note_date` (anchor pill) and task targets keep their existing destinations; the reminder edit/delete behaviour from #1939 is untouched.

### Backward compatibility

No schema, contract, IPC or sync change — `pnpm ipc:check` reports the invoke map unchanged. A journal reminder's `targetId` is already validated as `YYYY-MM-DD` by `reminders-api` at creation, so every row an older build wrote navigates exactly as intended; the new guard only catches values that could never have opened the right day anyway. Reminders stored by older versions are not rewritten.

### Assumptions

- Reminders keep the singleton `/journal` path rather than moving to the `memry://journal/<date>` tab shape (`/journal/<date>` + `entityId`) that relation chips use. Both land on the right day; the singleton path moves the open journal tab to that date instead of opening a second journal tab, which is the behaviour the inbox surfaces have today. Unifying the two tab shapes is a UX decision of its own and out of scope here.
- Giving the notification path a working `task` case is a behaviour change (it previously did nothing), taken deliberately as part of collapsing onto the shared builder.
- The malformed-target failure reuses the existing `reminder.dataUnavailable` string rather than minting a new key across 30+ locales.

## Release note

Clicking a journal reminder — in the toast, in the system notification, or in the inbox reminders list — now opens the journal day the reminder was set for instead of today's entry.

## Test plan

- `pnpm lint` · `pnpm typecheck` · `pnpm check:architecture` · `pnpm check:contracts` · `pnpm ipc:generate && pnpm ipc:check` · `pnpm --filter @memry/desktop i18n:check` — all pass
- `pnpm --filter @memry/desktop test:renderer` — 736 files / 9063 tests pass. (`pnpm test:desktop` as a whole died with a SIGSEGV in the `shared` project's better-sqlite3 tests on this machine, unrelated to this change and before it too; CI covers it.)
- `pnpm docs:impact --base origin/main --strict` and `pnpm docs:build` — the reminders guide now states that opening a reminder lands on its own journal day.
- New/updated tests: `open-reminder-target.test.ts` (journal tab keeps `/journal` + `viewState.date`, leap day, malformed ids incl. `2026-02-31` → `null`, plus `isJournalDateId`), `medium-cold-surfaces.test.tsx` (OS-notification click and toast "View" open the stored date; a note reminder unchanged; a malformed journal target opens nothing and reports), `reminder-detail.test.tsx` (journal source button opens its date; unusable date opens nothing), `tab-crud-reducer.test.ts` (cross-group singleton focus carries `viewState` and does not clone the tab).
- New E2E `journal-reminder-navigation.e2e.ts`: creates a journal reminder 40 days back, fires the real `reminder:clicked` IPC event from the main process, types into whatever journal the app landed on, and asserts the text ends up in the target day's vault file and not today's. Not run locally — the shared `ready(page)` beforeEach times out on this machine; relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)