### PR TITLE
feat(home): show upcoming days in the journal widget (#2075)

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/widgets/journal-widget-upcoming.test.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/journal-widget-upcoming.test.tsx
@@ -1,0 +1,156 @@
+import type React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { HeatmapEntry, JournalEntry } from '../../../../../preload/index.d'
+import { useJournalChangeEvents } from '@/hooks/use-journal-change-events'
+import { APP_QUERY_DEFAULT_OPTIONS } from '@/lib/query-client-options'
+import { JournalWidget } from './journal-widget'
+
+const { mockGetEntry, mockGetHeatmap, mockOpenTab, createdListeners } = vi.hoisted(() => ({
+  mockGetEntry: vi.fn(),
+  mockGetHeatmap: vi.fn(),
+  mockOpenTab: vi.fn(),
+  createdListeners: new Set<(event: { date: string }) => void>()
+}))
+
+vi.mock('@/services/journal-service', () => ({
+  journalService: { getEntry: mockGetEntry, getHeatmap: mockGetHeatmap },
+  onJournalEntryCreated: (callback: (event: { date: string }) => void) => {
+    createdListeners.add(callback)
+    return () => createdListeners.delete(callback)
+  },
+  onJournalEntryUpdated: () => () => {},
+  onJournalEntryDeleted: () => () => {},
+  onJournalExternalChange: () => () => {}
+}))
+
+vi.mock('@/hooks/use-general-settings', () => ({
+  useGeneralSettings: () => ({ settings: { clockFormat: '24h' } })
+}))
+
+vi.mock('@/contexts/tabs/context', () => ({
+  useTabActions: () => ({ openTab: mockOpenTab })
+}))
+
+/**
+ * Today is pinned to a date that puts the upcoming window across a month *and* a year
+ * boundary, which is exactly the case the widget used to have no way to express.
+ */
+const TODAY = '2026-12-30'
+const UPCOMING = ['2026-12-30', '2026-12-31', '2027-01-01', '2027-01-02']
+
+function entry(date: string, content: string): JournalEntry {
+  return {
+    id: date,
+    date,
+    content,
+    wordCount: content.split(' ').length,
+    characterCount: content.length,
+    tags: [],
+    createdAt: `${date}T09:00:00.000Z`,
+    modifiedAt: `${date}T09:00:00.000Z`
+  }
+}
+
+const server = new Map<string, JournalEntry>()
+
+function heatmapFor(year: number): HeatmapEntry[] {
+  return [...server.values()]
+    .filter((e) => e.date.startsWith(String(year)))
+    .map((e) => ({ date: e.date, characterCount: e.content.length, level: 1 as const }))
+}
+
+function Harness(): React.JSX.Element {
+  useJournalChangeEvents()
+  return <JournalWidget config={{}} size="M" />
+}
+
+function renderWidget(): void {
+  const client = new QueryClient({ defaultOptions: APP_QUERY_DEFAULT_OPTIONS })
+  render(
+    <QueryClientProvider client={client}>
+      <Harness />
+    </QueryClientProvider>
+  )
+}
+
+function upcomingRows(): HTMLElement[] {
+  return screen.queryAllByTestId('journal-upcoming-day')
+}
+
+function rowFor(date: string): HTMLElement {
+  const row = upcomingRows().find((r) => r.dataset.date === date)
+  if (!row) throw new Error(`no upcoming row for ${date}`)
+  return row
+}
+
+describe('home journal widget upcoming days', () => {
+  beforeEach(() => {
+    // Local noon, so the widget's local-date snapshot is TODAY in every timezone.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date(`${TODAY}T12:00:00`))
+    createdListeners.clear()
+    server.clear()
+    mockOpenTab.mockReset()
+    mockGetEntry.mockReset()
+    mockGetEntry.mockImplementation(async (date: string) => server.get(date) ?? null)
+    mockGetHeatmap.mockReset()
+    mockGetHeatmap.mockImplementation(async (year: number) => heatmapFor(year))
+  })
+
+  it('lists today and the next three local days, across month and year boundaries', async () => {
+    renderWidget()
+    await waitFor(() => expect(upcomingRows()).toHaveLength(4))
+    expect(upcomingRows().map((r) => r.dataset.date)).toEqual(UPCOMING)
+  })
+
+  it('previews a future entry and leaves the other days marked empty', async () => {
+    server.set('2027-01-01', entry('2027-01-01', 'Fly home, then unpack slowly.'))
+    renderWidget()
+
+    await waitFor(() =>
+      expect(rowFor('2027-01-01').textContent).toContain('Fly home, then unpack slowly.')
+    )
+    expect(rowFor('2027-01-02').textContent).toContain('No entry yet')
+    expect(rowFor('2026-12-31').textContent).toContain('No entry yet')
+  })
+
+  it('opens the journal tab with the clicked future ISO date', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    renderWidget()
+    await waitFor(() => expect(upcomingRows()).toHaveLength(4))
+
+    await user.click(rowFor('2027-01-02'))
+
+    expect(mockOpenTab).toHaveBeenCalledTimes(1)
+    expect(mockOpenTab.mock.calls[0][0]).toMatchObject({
+      type: 'journal',
+      viewState: { date: '2027-01-02' }
+    })
+  })
+
+  // The widget never refetches on its own, so without the app-level listener the
+  // 30s staleTime would keep serving the empty cache long after the entry landed.
+  it('picks up an entry written for a future day while the widget is mounted', async () => {
+    renderWidget()
+    await waitFor(() => expect(rowFor('2026-12-31').textContent).toContain('No entry yet'))
+
+    server.set('2026-12-31', entry('2026-12-31', 'Pack for the flight.'))
+    for (const listener of [...createdListeners]) listener({ date: '2026-12-31' })
+
+    await waitFor(() => expect(rowFor('2026-12-31').textContent).toContain('Pack for the flight.'))
+  })
+
+  it('reads at most one entry per upcoming day', async () => {
+    renderWidget()
+    await waitFor(() => expect(upcomingRows()).toHaveLength(4))
+    await waitFor(() => expect(mockGetEntry).toHaveBeenCalled())
+
+    const requested = mockGetEntry.mock.calls.map((call) => call[0] as string)
+    for (const date of UPCOMING) {
+      expect(requested.filter((d) => d === date)).toHaveLength(1)
+    }
+  })
+})

--- a/apps/desktop/src/renderer/src/components/home/widgets/journal-widget.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/journal-widget.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { formatTimeOfDay } from '@/lib/time-format'
 import {
   buildWeekDays,
+  buildUpcomingDays,
   recentEntryDates,
   relativeDayLabel,
   entrySnippet
@@ -49,11 +50,26 @@ export function JournalWidget({ size }: WidgetComponentProps): React.JSX.Element
     [todayIso, entryDates, lang]
   )
   const recentDates = useMemo(() => recentEntryDates(allEntries, limit), [allEntries, limit])
+  const upcomingDays = useMemo(() => buildUpcomingDays(todayIso, lang), [todayIso, lang])
 
   const entryQueries = useQueries({
     queries: recentDates.map((date) => ({
       queryKey: journalKeys.entry(date),
       queryFn: () => journalService.getEntry(date),
+      staleTime: ENTRY_STALE_TIME,
+      gcTime: ENTRY_GC_TIME
+    }))
+  })
+
+  // One read per upcoming day and no more: the window is a fixed four days, so this
+  // cannot fan out per rendered day of an open-ended range. Read the entry cache
+  // directly instead of gating on the heatmap -- the window can cross into a year no
+  // heatmap covers (Dec 30 -> Jan 1), and these are the keys `useJournalChangeEvents`
+  // already invalidates, so an entry written for a future day refreshes this section.
+  const upcomingQueries = useQueries({
+    queries: upcomingDays.map((day) => ({
+      queryKey: journalKeys.entry(day.iso),
+      queryFn: () => journalService.getEntry(day.iso),
       staleTime: ENTRY_STALE_TIME,
       gcTime: ENTRY_GC_TIME
     }))
@@ -163,6 +179,48 @@ export function JournalWidget({ size }: WidgetComponentProps): React.JSX.Element
           )
         })
       )}
+
+      {/* Upcoming: today plus the next three local days. Navigation targets first,
+          previews second -- an empty day stays clickable and is never dressed up as
+          an entry. Calendar events deliberately stay in the calendar widget. */}
+      <section className="mt-0.5 flex flex-col border-t pt-2.5">
+        <h3 className="mb-1 text-[10px] font-semibold uppercase tracking-[0.07em] text-text-tertiary">
+          {t('home.widget.journalUpcoming')}
+        </h3>
+        {upcomingDays.map((day, index) => {
+          const entry = upcomingQueries[index]?.data
+          const snippet = entry ? entrySnippet(entry.content, 60) : ''
+          return (
+            <button
+              key={day.iso}
+              type="button"
+              data-testid="journal-upcoming-day"
+              data-date={day.iso}
+              onClick={() => openJournal(day.iso)}
+              className="-mx-2 flex items-baseline gap-2 rounded px-2 py-1 text-start hover:bg-muted/40 active:bg-muted/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
+            >
+              <span
+                className={`w-20 shrink-0 text-[12px] font-medium ${
+                  day.isToday ? 'text-[var(--tint)]' : 'text-foreground/80'
+                }`}
+              >
+                {index === 0
+                  ? t('home.widget.journalToday')
+                  : index === 1
+                    ? t('home.widget.journalTomorrow')
+                    : `${day.weekdayShort} ${day.dayNum}`}
+              </span>
+              <span
+                className={`truncate text-[12px] leading-5 ${
+                  snippet ? 'text-text-tertiary' : 'text-muted-foreground/70'
+                }`}
+              >
+                {snippet || t('home.widget.journalNoEntryYet')}
+              </span>
+            </button>
+          )
+        })}
+      </section>
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/lib/home/journal-widget-data.test.ts
+++ b/apps/desktop/src/renderer/src/lib/home/journal-widget-data.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import type { HeatmapEntry } from '../../../../preload/index.d'
 import {
   buildWeekDays,
+  buildUpcomingDays,
   recentEntryDates,
   relativeDayLabel,
   entrySnippet
@@ -97,5 +98,65 @@ describe('entrySnippet wiki links (issue #1556)', () => {
 
   it('reads an aliased link as its alias, not the raw target|alias run', () => {
     expect(entrySnippet('see [[Sprint Notes|retro]] today')).toBe('see retro today')
+  })
+})
+
+describe('buildUpcomingDays', () => {
+  it('returns today first, then the next three days', () => {
+    const days = buildUpcomingDays('2026-06-23', 'en-US')
+    expect(days.map((d) => d.iso)).toEqual(['2026-06-23', '2026-06-24', '2026-06-25', '2026-06-26'])
+    expect(days[0].isToday).toBe(true)
+    expect(days.slice(1).every((d) => !d.isToday)).toBe(true)
+    expect(days[3].dayNum).toBe(26)
+    expect(days[0].weekdayShort).toBeTruthy()
+  })
+
+  it('crosses a month boundary', () => {
+    expect(buildUpcomingDays('2026-06-29', 'en-US').map((d) => d.iso)).toEqual([
+      '2026-06-29',
+      '2026-06-30',
+      '2026-07-01',
+      '2026-07-02'
+    ])
+  })
+
+  it('crosses a year boundary', () => {
+    expect(buildUpcomingDays('2026-12-30', 'en-US').map((d) => d.iso)).toEqual([
+      '2026-12-30',
+      '2026-12-31',
+      '2027-01-01',
+      '2027-01-02'
+    ])
+  })
+
+  it('crosses a leap day', () => {
+    expect(buildUpcomingDays('2028-02-27', 'en-US').map((d) => d.iso)).toEqual([
+      '2028-02-27',
+      '2028-02-28',
+      '2028-02-29',
+      '2028-03-01'
+    ])
+  })
+
+  // Local calendar arithmetic, not UTC or +24h: a 23- or 25-hour day inside the window
+  // must still advance exactly one calendar date, in whatever zone the run happens in.
+  it('advances one calendar day at a time across DST transition dates', () => {
+    for (const start of ['2026-03-07', '2026-10-31', '2026-03-27', '2026-11-01']) {
+      const days = buildUpcomingDays(start, 'en-US')
+      expect(days).toHaveLength(4)
+      for (let i = 1; i < days.length; i++) {
+        const previous = new Date(`${days[i - 1].iso}T12:00:00Z`)
+        const current = new Date(`${days[i].iso}T12:00:00Z`)
+        expect(current.getTime() - previous.getTime()).toBe(24 * 60 * 60 * 1000)
+        expect(days[i].dayNum).toBe(Number(days[i].iso.slice(8)))
+      }
+    }
+  })
+
+  it('honours an explicit count', () => {
+    expect(buildUpcomingDays('2026-06-23', 'en-US', 2).map((d) => d.iso)).toEqual([
+      '2026-06-23',
+      '2026-06-24'
+    ])
   })
 })

--- a/apps/desktop/src/renderer/src/lib/home/journal-widget-data.ts
+++ b/apps/desktop/src/renderer/src/lib/home/journal-widget-data.ts
@@ -9,6 +9,13 @@ export interface WeekDay {
   isToday: boolean
 }
 
+export interface UpcomingDay {
+  iso: string
+  dayNum: number
+  weekdayShort: string
+  isToday: boolean
+}
+
 export type RelativeDayLabel =
   { kind: 'today' } | { kind: 'yesterday' } | { kind: 'date'; text: string }
 
@@ -37,6 +44,29 @@ export function buildWeekDays(todayIso: string, entryDates: Set<string>, lang: s
       weekdayNarrow: d.toLocaleDateString(lang, { weekday: 'narrow' }),
       hasEntry: entryDates.has(iso),
       isToday: iso === todayIso
+    })
+  }
+  return days
+}
+
+/**
+ * `count` consecutive days starting at `todayIso` (today first, then the future).
+ *
+ * All arithmetic runs on local calendar fields, never UTC: `parseIso` lands on local
+ * midnight and `setDate` steps whole local days, so a DST boundary inside the window
+ * still advances exactly one calendar day.
+ */
+export function buildUpcomingDays(todayIso: string, lang: string, count = 4): UpcomingDay[] {
+  const today = parseIso(todayIso)
+  const days: UpcomingDay[] = []
+  for (let offset = 0; offset < count; offset++) {
+    const d = new Date(today)
+    d.setDate(today.getDate() + offset)
+    days.push({
+      iso: toLocalIso(d),
+      dayNum: d.getDate(),
+      weekdayShort: d.toLocaleDateString(lang, { weekday: 'short' }),
+      isToday: offset === 0
     })
   }
   return days

--- a/apps/desktop/tests/e2e/home-journal-widget-upcoming.e2e.ts
+++ b/apps/desktop/tests/e2e/home-journal-widget-upcoming.e2e.ts
@@ -1,0 +1,106 @@
+// @ts-nocheck - E2E specs run outside the app tsconfig; `page` is fixture-typed.
+/**
+ * Home journal widget upcoming days (#2075)
+ *
+ * The widget used to look only backwards: a seven-day history strip and the most
+ * recent entries. It now also lists today plus the next three local calendar days,
+ * so a future entry is visible and an empty future day is still a navigation target.
+ *
+ * Both cases run without a reload: the upcoming previews have to arrive from the
+ * journal broadcast, and the click has to open the journal tab on the exact date.
+ */
+
+import { test, expect } from './fixtures'
+import {
+  waitForAppReady,
+  waitForVaultReady,
+  dismissFirstRunOnboarding
+} from './utils/electron-helpers'
+
+const SEL = {
+  homePage: '[data-testid="home-page"]',
+  grid: '.home-grid',
+  widget: '[data-testid="widget"]',
+  journalWidget: '[data-testid="widget"][data-widget-type="journal"]',
+  gallery: '[data-testid="widget-gallery"]',
+  galleryItem: '[data-testid="widget-gallery-item"]',
+  addWidgetTrigger: '[data-testid="add-widget-trigger"]',
+  upcomingDay: '[data-testid="journal-upcoming-day"]'
+}
+
+async function ready(page) {
+  await waitForAppReady(page)
+  await waitForVaultReady(page)
+  await dismissFirstRunOnboarding(page)
+  await expect(page.locator(SEL.homePage)).toBeVisible({ timeout: 20000 })
+  await expect(page.locator(`${SEL.grid} ${SEL.widget}`)).toHaveCount(2, { timeout: 20000 })
+}
+
+async function addJournalWidget(page) {
+  const trigger = page.locator(SEL.addWidgetTrigger)
+  await expect(trigger).toBeVisible({ timeout: 20000 })
+  await trigger.click()
+  await expect(page.locator(SEL.gallery)).toBeVisible({ timeout: 20000 })
+  await page.locator(`${SEL.galleryItem}[data-widget-type="journal"]`).click()
+  await expect(page.locator(SEL.gallery)).toBeHidden({ timeout: 20000 })
+  await expect(page.locator(SEL.journalWidget)).toBeVisible({ timeout: 20000 })
+}
+
+/** Local calendar arithmetic, matching what the widget derives from the wall clock. */
+function localIsoInDays(offset: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + offset)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate()
+  ).padStart(2, '0')}`
+}
+
+async function writeEntry(page, date: string, content: string): Promise<void> {
+  await page.evaluate(
+    async ({ date, content }) => {
+      await window.api.journal.updateEntry({ date, content })
+    },
+    { date, content }
+  )
+}
+
+test.describe('Home journal widget upcoming days (#2075)', () => {
+  test('lists today and the next three days, previewing a future entry', async ({ page }) => {
+    await ready(page)
+    await addJournalWidget(page)
+
+    const widget = page.locator(SEL.journalWidget)
+    const rows = widget.locator(SEL.upcomingDay)
+    await expect(rows).toHaveCount(4, { timeout: 20000 })
+
+    for (let offset = 0; offset < 4; offset++) {
+      await expect(rows.nth(offset)).toHaveAttribute('data-date', localIsoInDays(offset))
+    }
+
+    const futureIso = localIsoInDays(2)
+    const text = `Upcoming journal ${Date.now()}`
+    const futureRow = widget.locator(`${SEL.upcomingDay}[data-date="${futureIso}"]`)
+    await expect(futureRow).not.toContainText(text)
+
+    // No reload: the broadcast alone has to bring the preview into the upcoming row.
+    await writeEntry(page, futureIso, text)
+    await expect(futureRow).toContainText(text, { timeout: 15000 })
+  })
+
+  test('clicking an empty future day opens the journal on that date', async ({ page }) => {
+    await ready(page)
+    await addJournalWidget(page)
+
+    const widget = page.locator(SEL.journalWidget)
+    const targetIso = localIsoInDays(3)
+    const targetRow = widget.locator(`${SEL.upcomingDay}[data-date="${targetIso}"]`)
+    await expect(targetRow).toBeVisible({ timeout: 20000 })
+
+    await targetRow.click()
+
+    // The journal page's own heading is the proof the tab opened on that exact day,
+    // not on today.
+    const heading = page.locator('h1').first()
+    await expect(heading).toContainText(String(Number(targetIso.slice(8))), { timeout: 20000 })
+  })
+})

--- a/apps/docs/src/user-guide/home-dashboard.md
+++ b/apps/docs/src/user-guide/home-dashboard.md
@@ -36,17 +36,17 @@ If two devices reorder boards at the same time, the last write wins for position
 
 Widgets are the cards on a board. Available types:
 
-| Widget          | Shows                                                   |
-| --------------- | ------------------------------------------------------- |
-| Recently Edited | Notes ordered by last-modified, most recent first       |
-| Recently Opened | Notes and canvases ordered by when you last opened them |
-| Bookmarks       | Your bookmarked notes                                   |
-| Tasks           | Tasks, with an inline filter and count                  |
-| Inbox           | Unfiled inbox items, with a triage row                  |
-| Folder          | The contents of a chosen folder                         |
-| Calendar        | An at-a-glance calendar of upcoming entries             |
-| Journal         | Today's journal entry and your current streak           |
-| Project         | One project's overview, tasks, notes, files and events  |
+| Widget          | Shows                                                     |
+| --------------- | --------------------------------------------------------- |
+| Recently Edited | Notes ordered by last-modified, most recent first         |
+| Recently Opened | Notes and canvases ordered by when you last opened them   |
+| Bookmarks       | Your bookmarked notes                                     |
+| Tasks           | Tasks, with an inline filter and count                    |
+| Inbox           | Unfiled inbox items, with a triage row                    |
+| Folder          | The contents of a chosen folder                           |
+| Calendar        | An at-a-glance calendar of upcoming entries               |
+| Journal         | Recent and upcoming journal days, and your current streak |
+| Project         | One project's overview, tasks, notes, files and events    |
 
 **Recently Edited and Recently Opened are siblings, not duplicates.** The first answers "what did I change?", the second "what did I read?" — and a note you open without typing in it appears only in the second. Recently Opened also lists canvases: a canvas row carries its own icon and reopens the canvas when you click it. A note you open _and_ edit shows up in both; the row subtitle is what tells them apart, reading "opened 12m ago" on one and "edited 3m ago" on the other.
 
@@ -55,6 +55,8 @@ Unlike everything else on a board, the Recently Opened **list** is per-device: i
 The Calendar widget shows today's events. New events reach it on their own: create one on the Calendar tab, or in the day panel, or let a connected calendar sync one in while you are working somewhere else, and the widget has it the next time the board is in front of you. There is nothing to refresh and no need to restart, and that holds whether or not the board was the tab you were looking at when the event appeared. If you leave Memry open overnight it rolls over on its own at local midnight — the widget, its event count, and the "Next:" line all switch to the new day without a restart. The same applies after the machine wakes from sleep or the system clock changes. "Today" means your local day, from midnight to midnight on your own clock, and the event count in the board header reads exactly the same day as the widget below it — a late-evening or just-after-midnight event that one shows, the other counts. The header's event count is the widget's row count and nothing more: a task due today is not an event, so it does not appear in the widget and is not counted as one in the header — it is already in the header's tasks-due count.
 
 The Journal widget keeps up the same way. Write on the Journal tab, let an edit arrive from another device, or change the day's file outside Memry, and the widget's week strip and its entry previews catch up on their own — the next time the board is in front of you if it was sitting in a background tab. There is nothing to refresh, and you do not have to leave the page and come back. The days it marks are your local days, so an entry written just before midnight belongs to the day you wrote it on.
+
+Under the week strip and the recent entries, the Journal widget lists **Upcoming**: today and the next three days on your own calendar. A day you have already written for shows the start of that entry; a day you have not shows "No entry yet" and is still a button. Click any of them and the Journal tab opens on exactly that date, including one in next month or next year — so writing tomorrow's plan is one click, not a walk through the date picker. Calendar events are not repeated here; those stay in the Calendar widget.
 
 The Project widget is a chosen project in miniature. Its body has the same five tabs as the project page: **Overview**, **Tasks**, **Notes**, **Files** and **Events**. Rows behave as they do on the page — open a note, tick a task off, change a status or a priority. Pick the project from the pill in the widget's header, the way the Folder widget picks its folder; the pill carries the project's colour and name, so several project widgets side by side stay tellable apart.
 

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -770,6 +770,9 @@
       "journalStreak": "{count, plural, one {#-day streak} other {#-day streak}}",
       "journalToday": "Today",
       "journalYesterday": "Yesterday",
+      "journalTomorrow": "Tomorrow",
+      "journalUpcoming": "Upcoming",
+      "journalNoEntryYet": "No entry yet",
       "loadError": "Couldn't load",
       "unknown": "Unknown widget"
     },


### PR DESCRIPTION
## Summary

Closes #2075.

The Home journal widget only ever looked backwards — a seven-day history strip and the most recent entries — so a future day was unreachable without walking the Journal tab's date picker.

- A new **Upcoming** section lists today plus the next three local calendar days. `buildUpcomingDays` steps local calendar fields, never UTC or a fixed +24h, so a DST boundary inside the window still advances exactly one date; month, year and leap-day rollovers are covered by tests.
- A day that already has an entry shows the start of it. A day that does not says "No entry yet" and stays a button — it is never dressed up as an entry.
- Clicking a day opens the journal tab with that exact ISO date in `viewState` (the path #2157 landed), including a date in next month or next year.
- Previews read `journalKeys.entry(date)` — exactly four reads, never one per rendered day — so the app-level `useJournalChangeEvents` listener from #2158 already invalidates them. No new invalidation wiring was needed, and an entry written for a future day appears with no refresh.

Assumptions / judgment calls:

- Reading the entry cache instead of gating on the heatmap. The heatmap covers only this year and last, so a window crossing Dec 30 → Jan 1 has no heatmap to consult. Four bounded local reads is both simpler and correct there.
- The window is the same four days at S/M/L. The rows are single-line and truncate, so the section stays readable at every size rather than changing shape per tier.
- No calendar events here, per the issue: those stay the Calendar widget's surface.
- Only `en` strings were added; every other locale falls back, matching how recent string additions have landed.

## Release note

The Home journal widget now shows an Upcoming section with today and the next three days. Days you have already written for show a preview; empty days are still one click away from writing.

## Test plan

- `pnpm --filter @memry/desktop test:renderer` (full renderer suite, 738 files green), plus focused runs of the new `journal-widget-data.test.ts` cases (upcoming window, month/year/leap rollover, DST-safe local stepping) and `journal-widget-upcoming.test.tsx` (four rows across a year boundary, entry-vs-empty rendering, click opens the exact ISO date, refresh on a journal-created broadcast, one read per day).
- New E2E `tests/e2e/home-journal-widget-upcoming.e2e.ts` — row dates, preview without reload, and click-to-date. E2E does not run on this machine (the shared `ready(page)` beforeEach times out locally), so it is relied on through CI.
- `pnpm lint`, `pnpm typecheck`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm --filter @memry/desktop i18n:check`, `git diff --check`.
- `pnpm docs:impact --base origin/main --strict` (clean) and `pnpm docs:build`; the Home dashboard user guide documents the new section.
- No contract or IPC surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)