### PR TITLE
feat(desktop): add a switch-vault keyboard shortcut

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.tsx
+++ b/apps/desktop/src/renderer/src/App.test.tsx
@@ -128,6 +128,7 @@ vi.mock('@/hooks', () => ({
   useMouseNavButtons: vi.fn(),
   useChordShortcuts: () => true,
   useSettingsShortcut: vi.fn(),
+  useSwitchVaultShortcut: vi.fn(),
   useNewNoteShortcut: (callback: () => void) => {
     newNoteShortcut = callback
   },

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -38,6 +38,7 @@ import {
   useTaskOrder,
   useVault,
   useSettingsShortcut,
+  useSwitchVaultShortcut,
   useNewNoteShortcut,
   useUndoKeyboardShortcut,
   useReminderNotifications,
@@ -48,6 +49,7 @@ import {
 } from '@/hooks'
 import { matchesShortcut } from '@/hooks/use-keyboard-shortcuts-base'
 import { useShortcutBinding } from '@/lib/shortcut-bindings'
+import { requestVaultSwitcherOpen } from '@/lib/vault-switcher-open'
 import { HintModeProvider } from '@/contexts/hint-mode'
 import { HintOverlay, HintIndicator } from '@/components/hint-overlay'
 import { CommandPalette } from '@/components/search/command-palette'
@@ -232,6 +234,7 @@ const AppContent = (): React.JSX.Element => {
   const isChordActive = useChordShortcuts()
   const { open: openSettings } = useSettingsModal()
   useSettingsShortcut(openSettings)
+  useSwitchVaultShortcut(requestVaultSwitcherOpen)
   useNewNoteShortcut(() => void handleNewNote())
   useUndoKeyboardShortcut() // T051-T054: Cmd+Z for task undo
   useReminderNotifications() // T231-T233: In-app toast notifications for reminders

--- a/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
+++ b/apps/desktop/src/renderer/src/App.workspace-counts.test.tsx
@@ -160,6 +160,7 @@ vi.mock('@/hooks', () => ({
   useMouseNavButtons: vi.fn(),
   useChordShortcuts: () => true,
   useSettingsShortcut: vi.fn(),
+  useSwitchVaultShortcut: vi.fn(),
   useNewNoteShortcut: vi.fn(),
   useUndoKeyboardShortcut: vi.fn(),
   useReminderNotifications: vi.fn(),

--- a/apps/desktop/src/renderer/src/components/keyboard/keyboard-shortcuts-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/keyboard/keyboard-shortcuts-dialog.tsx
@@ -54,6 +54,7 @@ const getShortcutGroups = (t: TFunction<'common'>): ShortcutGroup[] => {
         },
         { combos: [[mod, 'N']], description: t('shortcuts.items.general.createNote') },
         { combos: [[mod, ',']], description: t('shortcuts.items.general.openSettings') },
+        { combos: [[mod, shift, 'O']], description: t('shortcuts.items.general.switchVault') },
         {
           combos: [['?'], [mod, '/']],
           description: t('shortcuts.items.general.keyboardShortcuts')

--- a/apps/desktop/src/renderer/src/components/vault-switcher.shortcut.test.tsx
+++ b/apps/desktop/src/renderer/src/components/vault-switcher.shortcut.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Vault switcher — opening from the ⌘⇧O shortcut.
+ *
+ * The shortcut drives the sidebar's own picker, so these tests cover the wiring
+ * around it: opening, expanding a collapsed sidebar, Escape closing without a
+ * vault change, and handing focus back where it came from.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act, within } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import React from 'react'
+
+const mocks = vi.hoisted(() => ({
+  switchVault: vi.fn(),
+  selectVault: vi.fn(),
+  removeVault: vi.fn().mockResolvedValue(undefined),
+  openSettings: vi.fn(),
+  refresh: vi.fn(),
+  setSidebarOpen: vi.fn(),
+  setOpenMobile: vi.fn(),
+  sidebarOpen: true,
+  isMobile: false
+}))
+
+/**
+ * Radix's popover, reduced to the behaviour under test: it renders its content
+ * only while open, and Escape asks the owner to close.
+ */
+vi.mock('@/components/ui/picker', async () => {
+  const PickerContext = React.createContext<(value: string) => void>(() => {})
+  const OpenContext = React.createContext<{ open: boolean; onOpenChange: (o: boolean) => void }>({
+    open: false,
+    onOpenChange: () => {}
+  })
+  function Picker({
+    children,
+    onValueChange,
+    open,
+    onOpenChange
+  }: {
+    children: ReactNode
+    onValueChange: (value: string) => void
+    open: boolean
+    onOpenChange: (open: boolean) => void
+  }) {
+    return (
+      <OpenContext.Provider value={{ open, onOpenChange }}>
+        <PickerContext.Provider value={onValueChange}>{children}</PickerContext.Provider>
+      </OpenContext.Provider>
+    )
+  }
+  Picker.Trigger = ({ children }: { children: ReactNode }) => <>{children}</>
+  Picker.Content = ({ children }: { children: ReactNode }) => {
+    const { open, onOpenChange } = React.useContext(OpenContext)
+    if (!open) return null
+    return (
+      <div
+        data-testid="vault-picker"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onOpenChange(false)
+        }}
+      >
+        {children}
+      </div>
+    )
+  }
+  Picker.List = ({ children }: { children: ReactNode }) => <div>{children}</div>
+  Picker.Separator = () => <hr />
+  Picker.Empty = ({ message }: { message: string }) => <div>{message}</div>
+  Picker.Item = ({ value, label }: { value: string; label: string }) => {
+    const onValueChange = React.useContext(PickerContext)
+    return (
+      <button type="button" onClick={() => onValueChange(value)}>
+        {label}
+      </button>
+    )
+  }
+  return { Picker }
+})
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string, vars?: Record<string, unknown>) => (vars?.name ? `${key}:${vars.name}` : key)
+  })
+}))
+vi.mock('@/hooks/use-vault', () => ({
+  useVault: () => ({
+    status: { path: '/vaults/Active' },
+    isLoading: false,
+    selectVault: mocks.selectVault,
+    switchVault: mocks.switchVault
+  }),
+  useVaultList: () => ({
+    vaults: [
+      { path: '/vaults/Active', name: 'Active', vaultUuid: 'uuid-active' },
+      { path: '/vaults/Old', name: 'Old', vaultUuid: 'uuid-old' }
+    ],
+    removeVault: mocks.removeVault
+  })
+}))
+vi.mock('@/hooks/use-account-vaults', () => ({
+  useAccountVaults: () => ({ accountVaults: [], refresh: mocks.refresh })
+}))
+vi.mock('@/contexts/settings-modal-context', () => ({
+  useSettingsModal: () => ({ open: mocks.openSettings })
+}))
+vi.mock('@/contexts/auth-context', () => ({
+  useAuth: () => ({ state: { status: 'authenticated', email: 'k@example.com' } })
+}))
+vi.mock('@/components/ui/sidebar', () => ({
+  SidebarMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SidebarMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SidebarMenuButton: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  useSidebar: () => ({
+    isMobile: mocks.isMobile,
+    open: mocks.sidebarOpen,
+    setOpen: mocks.setSidebarOpen,
+    setOpenMobile: mocks.setOpenMobile
+  })
+}))
+vi.mock('@/components/download-vault-dialog', () => ({
+  DownloadVaultDialog: () => null
+}))
+
+import { VaultSwitcher } from './vault-switcher'
+import { requestVaultSwitcherOpen } from '@/lib/vault-switcher-open'
+
+describe('VaultSwitcher shortcut opening', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.sidebarOpen = true
+    mocks.isMobile = false
+    document.body.innerHTML = ''
+  })
+
+  it('stays closed until something asks it to open', () => {
+    render(<VaultSwitcher />)
+    expect(screen.queryByTestId('vault-picker')).not.toBeInTheDocument()
+  })
+
+  it('opens on an open request and lists the vaults, current one still selected', () => {
+    render(<VaultSwitcher />)
+
+    act(() => requestVaultSwitcherOpen())
+
+    const picker = screen.getByTestId('vault-picker')
+    expect(within(picker).getByText('Active')).toBeInTheDocument()
+    expect(within(picker).getByText('Old')).toBeInTheDocument()
+    expect(mocks.switchVault).not.toHaveBeenCalled()
+  })
+
+  it('expands a collapsed sidebar so the picker has an anchor, then restores it', () => {
+    mocks.sidebarOpen = false
+    render(<VaultSwitcher />)
+
+    act(() => requestVaultSwitcherOpen())
+    expect(mocks.setSidebarOpen).toHaveBeenCalledWith(true)
+
+    fireEvent.keyDown(screen.getByTestId('vault-picker'), { key: 'Escape' })
+    expect(mocks.setSidebarOpen).toHaveBeenLastCalledWith(false)
+  })
+
+  it('leaves an already-open sidebar alone', () => {
+    render(<VaultSwitcher />)
+
+    act(() => requestVaultSwitcherOpen())
+
+    expect(mocks.setSidebarOpen).not.toHaveBeenCalled()
+  })
+
+  it('opens the mobile sidebar instead of the desktop one', () => {
+    mocks.isMobile = true
+    mocks.sidebarOpen = false
+    render(<VaultSwitcher />)
+
+    act(() => requestVaultSwitcherOpen())
+
+    expect(mocks.setOpenMobile).toHaveBeenCalledWith(true)
+    expect(mocks.setSidebarOpen).not.toHaveBeenCalled()
+  })
+
+  it('closes on Escape without switching the vault', () => {
+    render(<VaultSwitcher />)
+    act(() => requestVaultSwitcherOpen())
+
+    fireEvent.keyDown(screen.getByTestId('vault-picker'), { key: 'Escape' })
+
+    expect(screen.queryByTestId('vault-picker')).not.toBeInTheDocument()
+    expect(mocks.switchVault).not.toHaveBeenCalled()
+  })
+
+  it('restores focus to wherever the shortcut was pressed', () => {
+    const opener = document.createElement('button')
+    document.body.appendChild(opener)
+    opener.focus()
+
+    render(<VaultSwitcher />)
+    act(() => requestVaultSwitcherOpen())
+
+    // Stand in for the picker taking focus, the way Radix does once it opens.
+    const inside = within(screen.getByTestId('vault-picker'))
+      .getByText('Old')
+      .closest('button') as HTMLButtonElement
+    inside.focus()
+    expect(document.activeElement).not.toBe(opener)
+
+    fireEvent.keyDown(screen.getByTestId('vault-picker'), { key: 'Escape' })
+
+    expect(document.activeElement).toBe(opener)
+  })
+
+  it('switches the vault when one is picked', () => {
+    render(<VaultSwitcher />)
+    act(() => requestVaultSwitcherOpen())
+
+    fireEvent.click(screen.getByText('Old'))
+
+    expect(mocks.switchVault).toHaveBeenCalledWith('/vaults/Old')
+  })
+
+  it('stops listening once unmounted', () => {
+    const { unmount } = render(<VaultSwitcher />)
+    unmount()
+
+    expect(() => act(() => requestVaultSwitcherOpen())).not.toThrow()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/vault-switcher.test.tsx
+++ b/apps/desktop/src/renderer/src/components/vault-switcher.test.tsx
@@ -75,7 +75,7 @@ vi.mock('@/components/ui/sidebar', () => ({
   SidebarMenuButton: ({ children }: { children: ReactNode }) => (
     <button type="button">{children}</button>
   ),
-  useSidebar: () => ({ isMobile: false })
+  useSidebar: () => ({ isMobile: false, open: true, setOpen: vi.fn(), setOpenMobile: vi.fn() })
 }))
 vi.mock('@/components/download-vault-dialog', () => ({
   DownloadVaultDialog: () => null

--- a/apps/desktop/src/renderer/src/components/vault-switcher.tsx
+++ b/apps/desktop/src/renderer/src/components/vault-switcher.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { Plus, Check, Loader2, X, Cloud, Trash2 } from '@/lib/icons'
 
 import { Picker } from '@/components/ui/picker'
@@ -28,12 +28,13 @@ import { useSettingsModal } from '@/contexts/settings-modal-context'
 import { useAuth } from '@/contexts/auth-context'
 import { DownloadVaultDialog } from '@/components/download-vault-dialog'
 import { extractErrorMessage } from '@/lib/ipc-error'
+import { useVaultSwitcherOpenRequest } from '@/lib/vault-switcher-open'
 import type { AccountVaultInfo, VaultInfo } from '../../../preload/index.d'
 import { useT } from '@memry/i18n/renderer'
 
 export function VaultSwitcher() {
   const { t: tPhaseF } = useT('common')
-  const { isMobile } = useSidebar()
+  const { isMobile, open: sidebarOpen, setOpen: setSidebarOpen, setOpenMobile } = useSidebar()
   const { status, isLoading, selectVault, switchVault } = useVault()
   const { vaults, removeVault } = useVaultList()
   const { open: openSettings } = useSettingsModal()
@@ -46,12 +47,63 @@ export function VaultSwitcher() {
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
 
+  /** Element focused when ⌘⇧O opened the switcher, so Escape can hand it back. */
+  const restoreFocusRef = useRef<HTMLElement | null>(null)
+  /** The shortcut may expand a collapsed sidebar; put it back when we are done. */
+  const collapseSidebarOnCloseRef = useRef(false)
+
   const isAuthenticated = authState.status === 'authenticated'
   const remoteOnlyVaults = accountVaults.filter((vault) => !vault.localPath)
 
   const currentVaultName = status?.path
     ? status.path.split('/').pop() || 'Vault'
     : 'No Vault Selected'
+
+  // ⌘⇧O (see `hooks/use-switch-vault-shortcut.ts`) opens this same picker rather
+  // than a second vault list, so switching from the shortcut and from the
+  // sidebar go through one code path.
+  useVaultSwitcherOpenRequest(
+    useCallback(() => {
+      if (open) return
+      const active = document.activeElement
+      restoreFocusRef.current = active instanceof HTMLElement ? active : null
+
+      if (isMobile) {
+        setOpenMobile(true)
+      } else if (!sidebarOpen) {
+        // The sidebar is `collapsible="offcanvas"`: while closed the trigger is
+        // parked off-screen and the popover would anchor to nothing.
+        collapseSidebarOnCloseRef.current = true
+        setSidebarOpen(true)
+      }
+
+      setOpen(true)
+      if (isAuthenticated) void refreshAccountVaults()
+    }, [
+      open,
+      isMobile,
+      sidebarOpen,
+      setOpenMobile,
+      setSidebarOpen,
+      isAuthenticated,
+      refreshAccountVaults
+    ])
+  )
+
+  // Runs for every close — Escape, an outside click, or picking a vault — because
+  // the picker's own state can close it without going through `onOpenChange`.
+  useEffect(() => {
+    if (open) return
+
+    if (collapseSidebarOnCloseRef.current) {
+      collapseSidebarOnCloseRef.current = false
+      setSidebarOpen(false)
+    }
+
+    const previous = restoreFocusRef.current
+    restoreFocusRef.current = null
+    if (previous?.isConnected) previous.focus()
+  }, [open, setSidebarOpen])
 
   const handleSelectNewVault = useCallback(async () => {
     await selectVault()

--- a/apps/desktop/src/renderer/src/hooks/index.ts
+++ b/apps/desktop/src/renderer/src/hooks/index.ts
@@ -28,6 +28,7 @@ export * from './use-vault'
 
 // Settings
 export * from './use-settings-shortcut'
+export * from './use-switch-vault-shortcut'
 
 // New note
 export * from './use-new-note-shortcut'

--- a/apps/desktop/src/renderer/src/hooks/use-switch-vault-shortcut.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-switch-vault-shortcut.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Switch-vault shortcut (⌘⇧O / Ctrl+Shift+O)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const setPlatform = (platform: string): void => {
+  Object.defineProperty(navigator, 'platform', { value: platform, configurable: true })
+}
+
+type Hook = typeof import('./use-switch-vault-shortcut')
+type Bindings = typeof import('@/lib/shortcut-bindings')
+
+async function loadForPlatform(platform: string): Promise<{ hook: Hook; bindings: Bindings }> {
+  setPlatform(platform)
+  vi.resetModules()
+  const bindings = await import('@/lib/shortcut-bindings')
+  const hook = await import('./use-switch-vault-shortcut')
+  return { hook, bindings }
+}
+
+const press = (target: EventTarget, init: KeyboardEventInit): boolean =>
+  target.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }))
+
+describe('useSwitchVaultShortcut', () => {
+  const originalPlatform = navigator.platform
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    setPlatform(originalPlatform)
+    vi.resetModules()
+  })
+
+  it('fires on ⌘⇧O on macOS', async () => {
+    const { hook } = await loadForPlatform('MacIntel')
+    const onOpen = vi.fn()
+    renderHook(() => hook.useSwitchVaultShortcut(onOpen))
+
+    press(window, { key: 'o', metaKey: true, shiftKey: true })
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires on Ctrl+Shift+O off macOS', async () => {
+    const { hook } = await loadForPlatform('Win32')
+    const onOpen = vi.fn()
+    renderHook(() => hook.useSwitchVaultShortcut(onOpen))
+
+    press(window, { key: 'o', ctrlKey: true, shiftKey: true })
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores the unmodified O that the inbox uses', async () => {
+    const { hook } = await loadForPlatform('MacIntel')
+    const onOpen = vi.fn()
+    renderHook(() => hook.useSwitchVaultShortcut(onOpen))
+
+    press(window, { key: 'o' })
+    press(window, { key: 'o', metaKey: true })
+
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['input', () => document.createElement('input')],
+    ['textarea', () => document.createElement('textarea')],
+    ['select', () => document.createElement('select')]
+  ])('stays inert while a %s owns focus', async (_name, create) => {
+    const { hook } = await loadForPlatform('MacIntel')
+    const onOpen = vi.fn()
+    renderHook(() => hook.useSwitchVaultShortcut(onOpen))
+
+    const element = create()
+    document.body.appendChild(element)
+    element.focus()
+
+    press(element, { key: 'o', metaKey: true, shiftKey: true })
+
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('stays inert while a rich-text editor owns focus', async () => {
+    const { hook } = await loadForPlatform('MacIntel')
+    const onOpen = vi.fn()
+    renderHook(() => hook.useSwitchVaultShortcut(onOpen))
+
+    const editor = document.createElement('div')
+    editor.setAttribute('contenteditable', 'true')
+    editor.tabIndex = 0
+    document.body.appendChild(editor)
+    // jsdom does not derive isContentEditable from the attribute.
+    Object.defineProperty(editor, 'isContentEditable', { value: true, configurable: true })
+    editor.focus()
+
+    press(editor, { key: 'o', metaKey: true, shiftKey: true })
+
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('uses the registry default when older settings carry no binding for it', async () => {
+    const { hook, bindings } = await loadForPlatform('MacIntel')
+    // Settings written before this shortcut existed: overrides for other ids only.
+    bindings.__setShortcutOverridesForTests({
+      'nav.search': { key: 'j', modifiers: { meta: true } }
+    })
+
+    const onOpen = vi.fn()
+    renderHook(() => hook.useSwitchVaultShortcut(onOpen))
+
+    press(window, { key: 'o', metaKey: true, shiftKey: true })
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    bindings.__setShortcutOverridesForTests({})
+  })
+
+  it('honours a user rebind', async () => {
+    const { hook, bindings } = await loadForPlatform('MacIntel')
+    bindings.__setShortcutOverridesForTests({
+      'nav.switchVault': { key: 'y', modifiers: { meta: true, alt: true } }
+    })
+
+    const onOpen = vi.fn()
+    renderHook(() => hook.useSwitchVaultShortcut(onOpen))
+
+    press(window, { key: 'o', metaKey: true, shiftKey: true })
+    expect(onOpen).not.toHaveBeenCalled()
+
+    press(window, { key: 'y', metaKey: true, altKey: true })
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    bindings.__setShortcutOverridesForTests({})
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-switch-vault-shortcut.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-switch-vault-shortcut.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect } from 'react'
+import { useShortcutBinding } from '@/lib/shortcut-bindings'
+import { matchesShortcut } from './use-keyboard-shortcuts-base'
+import { isInputFocused } from './use-keyboard-shortcuts'
+
+/**
+ * Switch vault. ⌘⇧O (⌃⇧O off Mac) opens the sidebar's vault switcher from
+ * anywhere, so switching no longer means reopening the sidebar by hand.
+ *
+ * The chord stands down while a text input, textarea, select, or rich-text
+ * editor owns focus: those surfaces may map the same keys, and a shortcut that
+ * steals a keystroke mid-sentence is worse than no shortcut.
+ */
+export function useSwitchVaultShortcut(onOpen: () => void): void {
+  const binding = useShortcutBinding('nav.switchVault')
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!matchesShortcut(e, binding.key, binding.modifiers)) return
+      if (isInputFocused()) return
+
+      e.preventDefault()
+      e.stopPropagation()
+      onOpen()
+    },
+    [binding, onOpen]
+  )
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
+  }, [handleKeyDown])
+}

--- a/apps/desktop/src/renderer/src/lib/shortcut-registry.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcut-registry.ts
@@ -16,6 +16,7 @@ export type ShortcutId =
   | 'nav.newNote'
   | 'nav.search'
   | 'nav.settings'
+  | 'nav.switchVault'
   | 'tabs.closeTab'
   | 'tabs.nextTab'
   | 'tabs.prevTab'
@@ -84,6 +85,14 @@ export const SHORTCUT_REGISTRY: ShortcutEntry[] = [
     description: 'Open the settings panel',
     category: 'Navigation',
     defaultBinding: { key: ',', modifiers: { meta: true } }
+  },
+  {
+    id: 'nav.switchVault',
+    i18nKey: 'nav.switchVault',
+    label: 'Switch Vault',
+    description: 'Open the vault switcher',
+    category: 'Navigation',
+    defaultBinding: { key: 'o', modifiers: { meta: true, shift: true } }
   },
 
   // Tabs

--- a/apps/desktop/src/renderer/src/lib/vault-switcher-open.ts
+++ b/apps/desktop/src/renderer/src/lib/vault-switcher-open.ts
@@ -1,0 +1,39 @@
+/**
+ * Vault switcher open requests
+ *
+ * The vault switcher lives in the sidebar footer and owns its own popover
+ * state. The ⌘⇧O shortcut is registered app-wide in `App.tsx`, far from that
+ * component, so this module carries the request between them instead of
+ * duplicating vault-selection logic in a second surface.
+ *
+ * Module-level (not React context) for the same reason `lib/shortcut-bindings.ts`
+ * is: both ends mount in different trees, and tests can drive it directly.
+ */
+
+import { useEffect, useRef } from 'react'
+
+type Listener = () => void
+
+const listeners = new Set<Listener>()
+
+/** Ask the mounted vault switcher to open and take focus. */
+export function requestVaultSwitcherOpen(): void {
+  for (const listener of [...listeners]) listener()
+}
+
+/** Subscribe the vault switcher to open requests. */
+export function useVaultSwitcherOpenRequest(onRequest: () => void): void {
+  const handlerRef = useRef(onRequest)
+
+  useEffect(() => {
+    handlerRef.current = onRequest
+  }, [onRequest])
+
+  useEffect(() => {
+    const listener = (): void => handlerRef.current()
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  }, [])
+}

--- a/apps/desktop/tests/e2e/switch-vault-shortcut.e2e.ts
+++ b/apps/desktop/tests/e2e/switch-vault-shortcut.e2e.ts
@@ -1,0 +1,46 @@
+/**
+ * Switch-vault shortcut E2E.
+ *
+ * ⌘⇧O (⌃⇧O off macOS) opens the sidebar's vault switcher from anywhere, so a
+ * vault switch no longer starts with reopening the sidebar. Escape closes it
+ * again without touching the active vault.
+ */
+
+import type { Locator, Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { MOD, ready } from './utils/desktop-test-helpers'
+
+const SWITCH_VAULT = `${MOD}+Shift+O`
+
+function picker(page: Page): Locator {
+  return page.locator('[data-slot="picker-content"]')
+}
+
+test.describe('Switch vault shortcut', () => {
+  test.beforeEach(async ({ page }) => {
+    await ready(page)
+  })
+
+  test('opens the vault switcher and closes it on Escape', async ({ page }) => {
+    await expect(picker(page)).toHaveCount(0)
+
+    await page.keyboard.press(SWITCH_VAULT)
+
+    const content = picker(page).first()
+    await expect(content).toBeVisible()
+    await expect(content).toContainText(/vault/i)
+
+    await page.keyboard.press('Escape')
+    await expect(picker(page)).toHaveCount(0)
+  })
+
+  test('stays inert while the note editor owns the chord', async ({ page }) => {
+    const editor = page.locator('[contenteditable="true"]').first()
+    if ((await editor.count()) === 0) test.skip(true, 'No editor surface on the current view')
+
+    await editor.click()
+    await page.keyboard.press(SWITCH_VAULT)
+
+    await expect(picker(page)).toHaveCount(0)
+  })
+})

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -12,6 +12,9 @@ Default shortcuts. Entries in the Navigation, Tabs, and View categories are rebi
 | Go to sidebar section | <kbd>⌘</kbd>+<kbd>1</kbd> … <kbd>⌘</kbd>+<kbd>6</kbd>  |
 | Open search           | <kbd>⌘</kbd>+<kbd>K</kbd> or <kbd>⌘</kbd>+<kbd>P</kbd> |
 | Open settings         | <kbd>⌘</kbd>+<kbd>,</kbd>                              |
+| Switch vault          | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>O</kbd>                 |
+
+> **Switch vault** opens the vault switcher in the sidebar footer from anywhere — if the sidebar is hidden it slides open for the duration, and <kbd>Esc</kbd> closes the switcher and puts the sidebar back without changing vaults. Like the other app shortcuts it stands down while you are typing in a field or in the note editor.
 
 > Hold <kbd>⌘</kbd> (<kbd>Ctrl</kbd> on Windows / Linux) to reveal the section numbers on the sidebar icons, then press the number to jump — <kbd>⌘</kbd>+<kbd>1</kbd> opens Home, <kbd>⌘</kbd>+<kbd>2</kbd> Inbox, and so on. Numbers follow the sidebar's visible top-to-bottom order (Home is always 1), so they shift if you hide a section. This shortcut works everywhere, including inside the editor, and is fixed rather than rebindable.
 

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -903,6 +903,7 @@
         "quickSearch": "Open quick search",
         "createNote": "Create a note",
         "openSettings": "Open settings",
+        "switchVault": "Switch vault",
         "keyboardShortcuts": "Open keyboard shortcuts",
         "undoTaskAction": "Undo last task action",
         "toggleSidebar": "Toggle the sidebar",

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -1422,6 +1422,10 @@
         "settings": {
           "label": "Open Settings",
           "description": "Open the settings panel"
+        },
+        "switchVault": {
+          "label": "Switch Vault",
+          "description": "Open the vault switcher"
         }
       },
       "tabs": {


### PR DESCRIPTION
## Summary
<!-- What changed? -->
Closes #2076.

Switching vaults meant reopening the sidebar first. `Cmd/Ctrl+Shift+O` now opens the sidebar's **existing** vault switcher from anywhere — no second vault list, no duplicated selection logic.

- `nav.switchVault` is a normal `SHORTCUT_REGISTRY` entry, so it shows up in Settings → Keyboard Shortcuts, is rebindable, and participates in conflict detection. Settings written by older versions carry no binding for it, so they fall back to the registry default; no settings-schema or IPC change was needed.
- `lib/vault-switcher-open.ts` carries the request from the app-wide listener in `App.tsx` to the `VaultSwitcher` in the sidebar footer. Module-level for the same reason `lib/shortcut-bindings.ts` is: the two ends mount in different trees.
- The chord stands down while an input, textarea, select, or the note editor owns focus (`isInputFocused`), so it never steals a keystroke mid-sentence. The unmodified `O` the inbox uses is untouched, which is why the issue picked the modifier form.
- Escape closes the switcher without changing the vault and hands focus back to wherever the shortcut was pressed (the picker prevents Radix's own `onCloseAutoFocus`).
- Judgment call: the sidebar is `collapsible="offcanvas"`, so while it is closed the picker's trigger is parked off-screen and has nothing to anchor to. The shortcut therefore expands the sidebar for as long as the switcher is open and collapses it again on close, leaving the user's sidebar preference as it found it. On mobile it opens the Sheet instead.
- Also added the row to the shortcuts help dialog, the `en` i18n surfaces (other locales fall back to English, matching how the rest of the registry lands), and the docs shortcut table.

## Release note
<!-- User-facing release note, or `none` for internal-only changes. This feeds `pnpm release:humanize`. -->
Press Cmd+Shift+O (Ctrl+Shift+O on Windows and Linux) to open the vault switcher from anywhere, without reopening the sidebar first.

## Test plan
<!-- Commands run, or manual checks. -->
- New `use-switch-vault-shortcut.test.tsx`: fires on ⌘⇧O (macOS) and Ctrl+Shift+O (non-macOS), ignores the unmodified `O`, stays inert in input/textarea/select/contenteditable, uses the registry default when older settings carry no binding for it, and honours a rebind.
- New `vault-switcher.shortcut.test.tsx`: opens on request, expands and restores a collapsed sidebar, opens the mobile sheet instead, closes on Escape without calling `switchVault`, restores focus, still switches on pick, and unsubscribes on unmount.
- New `tests/e2e/switch-vault-shortcut.e2e.ts`: presses the chord and asserts the picker opens, then that Escape closes it, plus editor suppression. E2E does not run on this machine (the shared `ready(page)` beforeEach times out locally) — relying on CI for it.
- `pnpm lint`, `pnpm typecheck`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm --filter @memry/desktop i18n:check`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build`, `git diff --check` — all clean.
- `pnpm test:desktop`: 20199 passed. The only failing file is `crdt-sync-coordinator.test.ts`, which fails to load Electron in this fresh worktree ("Electron failed to install correctly") — an environment issue unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)