### PR TITLE
fix(updater): point the failed-install dialog at the real download page

### DIFF
--- a/apps/desktop/src/renderer/src/components/updater/update-install-failed-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-install-failed-dialog.test.tsx
@@ -107,7 +107,7 @@ describe('UpdateInstallFailedDialog', () => {
     await userEvent.click(screen.getByRole('button', { name: /download installer/i }))
 
     expect(open).toHaveBeenCalledWith(
-      'https://memrynote.com/download',
+      'https://memrynote.com/download/desktop',
       '_blank',
       'noopener,noreferrer'
     )

--- a/apps/desktop/src/renderer/src/components/updater/update-install-failed-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-install-failed-dialog.tsx
@@ -7,7 +7,7 @@ import { Download } from '@/lib/icons'
 import { useAppUpdater } from '@/hooks/use-app-updater'
 import memryLogo from '@/assets/icon-logo.png'
 
-const DOWNLOAD_URL = 'https://memrynote.com/download'
+const DOWNLOAD_URL = 'https://memrynote.com/download/desktop'
 
 /**
  * Only surfaces for an install that was attempted and never applied — the flag is

--- a/apps/docs/src/guide/install.md
+++ b/apps/docs/src/guide/install.md
@@ -66,7 +66,7 @@ is run by the version you currently have installed, not by the one being install
 these workarounds only take effect on updates _away from_ a build that contains them. If
 your updates are failing today, install the latest version manually once
 (uninstall from **Settings → Apps**, then run the installer from
-[the download page](https://memrynote.com/download); your vault and settings are kept).
+[the download page](https://memrynote.com/download/desktop); your vault and settings are kept).
 Updates after that run on their own.
 
 ## Run from Source

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -24,7 +24,8 @@
       "destination": "https://memrynote.com/:path",
       "permanent": true
     },
-    { "source": "/alternatives", "destination": "/compare", "permanent": true }
+    { "source": "/alternatives", "destination": "/compare", "permanent": true },
+    { "source": "/download", "destination": "/download/desktop", "permanent": true }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Summary
The failed-install recovery dialog's Download Installer button opened `https://memrynote.com/download`, a route that does not exist on the landing site (only `/download/desktop` does), so it landed on the NotFound page — reported by a user as "Download installer goes to a page with no option."

Fixes:
- `apps/landing/vercel.json`: permanent redirect `/download` -> `/download/desktop`, next to the existing `/alternatives` -> `/compare` redirect. This repairs the link for every already-installed client, whose dialog URL is baked into the shipped app and cannot be changed without an update.
- `apps/desktop/.../update-install-failed-dialog.tsx`: `DOWNLOAD_URL` now points straight at `/download/desktop`, so future builds skip the redirect hop. Updated the matching assertion in `update-install-failed-dialog.test.tsx`.
- `apps/docs/src/guide/install.md`: fixed the same stale `/download` link in the failed-update recovery paragraph.

## Release note
Fixed the failed-update dialog's download link, which pointed to a page that no longer existed.

## Test plan
- `pnpm exec vitest run --config config/vitest.config.ts --project renderer update-install-failed-dialog` (run from `apps/desktop`) — 10/10 passed.
- `pnpm --filter @memry/desktop typecheck:web` — passed.
- `pnpm docs:impact --base origin/main --strict` — `covered`.
- `pnpm docs:build` — built clean.
- `git diff --check origin/main HEAD` — clean.