### PR TITLE
feat(folder-view): suggest tags in filter values and open rows on middle click

### DIFF
--- a/apps/desktop/src/renderer/src/components/folder-view/filter-builder.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/filter-builder.tsx
@@ -27,6 +27,7 @@ import {
   getDefaultOperator
 } from '@/lib/filter-evaluator'
 import { FilterRow, type FilterCondition, type PropertyInfo } from './filter-row'
+import type { TagSuggestion } from '@/lib/tag-suggestions'
 import type { FilterExpression } from '@memry/contracts/folder-view-api'
 import { useT } from '@memry/i18n/renderer'
 
@@ -39,6 +40,11 @@ interface FilterBuilderProps {
   filters?: FilterExpression
   /** Available custom properties */
   availableProperties: Array<{ name: string; type: string; usageCount: number }>
+  /**
+   * Vault tags, offered as value suggestions on a `tags` condition. Omitted
+   * or empty, that value stays a plain text input.
+   */
+  tagSuggestions?: readonly TagSuggestion[]
   /** Built-in column info */
   builtInColumns: Array<{ id: string; displayName: string; type: string }>
   /** Called when filters change (debounced) */
@@ -220,6 +226,7 @@ function uiStateToFilterExpression(state: FilterUIState): FilterExpression | und
 export function FilterBuilder({
   filters,
   availableProperties,
+  tagSuggestions,
   builtInColumns,
   onFiltersChange,
   lockedCondition,
@@ -452,6 +459,9 @@ export function FilterBuilder({
               <Button
                 variant="ghost"
                 size="sm"
+                // Icon-only: without a name the button is unreachable by
+                // assistive tech (the tooltip is not an accessible name).
+                aria-label={tPhaseF('phaseF.componentsFolderViewFilterBuilder.filter')}
                 className={cn(
                   'gap-1.5 px-2 text-muted-foreground',
                   filterCount > 0 && 'text-foreground',
@@ -534,6 +544,7 @@ export function FilterBuilder({
                 key={condition.id}
                 condition={condition}
                 availableProperties={propertyInfos}
+                tagSuggestions={tagSuggestions}
                 onChange={(updated) => handleUpdateCondition(condition.id, updated)}
                 onRemove={() => handleRemoveCondition(condition.id)}
               />
@@ -578,6 +589,7 @@ export function FilterBuilder({
                     key={condition.id}
                     condition={condition}
                     availableProperties={propertyInfos}
+                    tagSuggestions={tagSuggestions}
                     onChange={(updated) =>
                       handleUpdateGroupCondition(group.id, condition.id, updated)
                     }

--- a/apps/desktop/src/renderer/src/components/folder-view/filter-row.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/filter-row.tsx
@@ -25,6 +25,8 @@ import { cn } from '@/lib/utils'
 import { getOperatorsForType, getDefaultOperator, type PropertyType } from '@/lib/filter-evaluator'
 import { stringifyUnknown } from '@/lib/stringify-unknown'
 import { getColumnLabel } from '@/lib/contract-display-names'
+import { TagValueInput } from './tag-value-input'
+import type { TagSuggestion } from '@/lib/tag-suggestions'
 import { useT } from '@memry/i18n/renderer'
 
 // ============================================================================
@@ -49,6 +51,11 @@ interface FilterRowProps {
   condition: FilterCondition
   /** Available properties for selection */
   availableProperties: PropertyInfo[]
+  /**
+   * Vault tags, for the `tags` property's value suggestions. Omitted (or
+   * empty) leaves that value a plain text input.
+   */
+  tagSuggestions?: readonly TagSuggestion[]
   /** Called when the condition changes */
   onChange: (condition: FilterCondition) => void
   /** Called when the condition should be removed */
@@ -97,6 +104,7 @@ function PropertyIcon({
 export function FilterRow({
   condition,
   availableProperties,
+  tagSuggestions,
   onChange,
   onRemove,
   className
@@ -184,6 +192,7 @@ export function FilterRow({
       {/* Property Selector — chip with a leading type icon */}
       <Select value={condition.property} onValueChange={handlePropertyChange}>
         <SelectTrigger
+          aria-label={tPhaseF('phaseF.componentsFolderViewFilterRow.placeholderProperty')}
           className={cn(
             CHIP,
             // SelectValue renders the selected item (icon + name); hide only the chevron.
@@ -230,6 +239,7 @@ export function FilterRow({
       {/* Operator Selector — chip with a trailing chevron */}
       <Select value={condition.operator} onValueChange={handleOperatorChange}>
         <SelectTrigger
+          aria-label={tPhaseF('phaseF.componentsFolderViewFilterRow.placeholderOperator')}
           className={cn(
             CHIP,
             'justify-start text-muted-foreground [&>svg:last-child]:h-3 [&>svg:last-child]:w-3'
@@ -254,6 +264,9 @@ export function FilterRow({
           type={currentProperty?.type || 'text'}
           value={condition.value}
           onChange={handleValueChange}
+          // Only the built-in `tags` column takes vault tags as its value; a
+          // custom multiselect has its own options, which these are not.
+          tagSuggestions={currentProperty?.id === 'tags' ? tagSuggestions : undefined}
         />
       )}
 
@@ -281,10 +294,24 @@ interface ValueInputProps {
   type: PropertyType
   value: unknown
   onChange: (value: unknown) => void
+  /** Vault tags to suggest; only set for the built-in `tags` property. */
+  tagSuggestions?: readonly TagSuggestion[]
 }
 
-function ValueInput({ type, value, onChange }: ValueInputProps): React.JSX.Element {
+function ValueInput({ type, value, onChange, tagSuggestions }: ValueInputProps): React.JSX.Element {
   const { t: tPhaseF } = useT('notes')
+
+  if (tagSuggestions && tagSuggestions.length > 0) {
+    return (
+      <TagValueInput
+        value={stringifyUnknown(value)}
+        onChange={onChange}
+        suggestions={tagSuggestions}
+        placeholder={tPhaseF('phaseF.componentsFolderViewFilterRow.placeholderValue')}
+      />
+    )
+  }
+
   switch (type) {
     case 'number':
     case 'rating':

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-gallery-view.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-gallery-view.tsx
@@ -11,6 +11,7 @@
 import { useCallback, useMemo, useRef } from 'react'
 import { Folder } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { handleMiddleClick } from '@/lib/middle-click'
 import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
 import type { NoteWithProperties } from '@memry/contracts/folder-view-api'
 import { FolderViewEmptyState } from './folder-view-empty-state'
@@ -28,6 +29,8 @@ export interface FolderGalleryViewProps {
   searchQuery?: string
   tagMetaMap: TagMetaMap
   onNoteOpen: (noteId: string) => void
+  /** Middle-click gesture: open the card in a background tab. */
+  onOpenInBackgroundTab?: (noteId: string) => void
   onTagClick?: (tag: string) => void
   onCreateNote?: () => void
   onClearAll?: () => void
@@ -45,6 +48,7 @@ export function FolderGalleryView({
   searchQuery,
   tagMetaMap,
   onNoteOpen,
+  onOpenInBackgroundTab,
   onTagClick,
   onCreateNote,
   onClearAll,
@@ -92,6 +96,7 @@ export function FolderGalleryView({
           role="button"
           tabIndex={0}
           onClick={() => onNoteOpen(note.id)}
+          onMouseDown={(e) => handleMiddleClick(e, () => onOpenInBackgroundTab?.(note.id))}
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault()

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-list-view.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-list-view.tsx
@@ -11,6 +11,7 @@
 import { useCallback, useMemo, useRef } from 'react'
 import { FileText } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { handleMiddleClick } from '@/lib/middle-click'
 import { useTabScrollRestore } from '@/hooks/use-tab-scroll-restore'
 import type { NoteWithProperties } from '@memry/contracts/folder-view-api'
 import { FolderViewEmptyState } from './folder-view-empty-state'
@@ -23,6 +24,8 @@ export interface FolderListViewProps {
   density?: 'comfortable' | 'compact'
   tagMetaMap: TagMetaMap
   onNoteOpen: (noteId: string) => void
+  /** Middle-click gesture: open the row in a background tab. */
+  onOpenInBackgroundTab?: (noteId: string) => void
   onTagClick?: (tag: string) => void
   onCreateNote?: () => void
   onClearAll?: () => void
@@ -41,6 +44,7 @@ export function FolderListView({
   density = 'comfortable',
   tagMetaMap,
   onNoteOpen,
+  onOpenInBackgroundTab,
   onTagClick,
   onCreateNote,
   onClearAll,
@@ -87,6 +91,7 @@ export function FolderListView({
           role="button"
           tabIndex={0}
           onClick={() => onNoteOpen(note.id)}
+          onMouseDown={(e) => handleMiddleClick(e, () => onOpenInBackgroundTab?.(note.id))}
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault()

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.test.tsx
@@ -591,6 +591,32 @@ describe('FolderTableView', () => {
     fireEvent.keyDown(grid, { key: 'm', metaKey: true, shiftKey: true })
     expect(onMoveToFolder).toHaveBeenCalledWith(['note-1', 'note-2', 'note-3'])
   })
+
+  it('opens a row in a background tab on middle click, and ignores other buttons', () => {
+    const onOpenInBackgroundTab = vi.fn()
+    const onNoteOpen = vi.fn()
+
+    render(
+      <FolderTableView
+        notes={notes}
+        columns={columns}
+        onNoteOpen={onNoteOpen}
+        onOpenInBackgroundTab={onOpenInBackgroundTab}
+      />
+    )
+
+    const grid = screen.getByRole('grid', { name: 'notesTable' })
+    const row = grid.querySelector('[data-row-id="note-1"]') as HTMLElement
+
+    fireEvent.mouseDown(row, { button: 0 })
+    expect(onOpenInBackgroundTab).not.toHaveBeenCalled()
+
+    const middle = fireEvent.mouseDown(row, { button: 1 })
+    expect(onOpenInBackgroundTab).toHaveBeenCalledWith('note-1')
+    // Suppressed so Chromium does not start autoscrolling the table.
+    expect(middle).toBe(false)
+    expect(onNoteOpen).not.toHaveBeenCalled()
+  })
 })
 
 describe('GroupedTable', () => {
@@ -940,6 +966,25 @@ describe('GroupedTable', () => {
     const grid = screen.getByRole('grid', { name: 'groupedNotesTable' })
     fireEvent.keyDown(grid, { key: 'm', metaKey: true, shiftKey: true })
     expect(onMoveToFolder).toHaveBeenCalledWith(['note-1', 'note-2'])
+  })
+
+  it('opens a grouped row in a background tab on middle click', () => {
+    const onOpenInBackgroundTab = vi.fn()
+
+    render(
+      <GroupedTable
+        notes={notes}
+        columns={columns}
+        groupBy={{ property: 'status' }}
+        onOpenInBackgroundTab={onOpenInBackgroundTab}
+      />
+    )
+
+    const grid = screen.getByRole('grid', { name: 'groupedNotesTable' })
+    const row = grid.querySelector('[data-row-id="note-1"]') as HTMLElement
+
+    fireEvent.mouseDown(row, { button: 1 })
+    expect(onOpenInBackgroundTab).toHaveBeenCalledWith('note-1')
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx
@@ -68,6 +68,7 @@ import {
   type AppIcon
 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { handleMiddleClick } from '@/lib/middle-click'
 import { getColumnLabel } from '@/lib/contract-display-names'
 import { evaluateFormula } from '@/lib/expression-evaluator'
 import { stringifyUnknown } from '@/lib/stringify-unknown'
@@ -130,6 +131,8 @@ interface FolderTableViewProps {
   onNoteOpen?: (noteId: string) => void
   /** Called when a note should be opened in a new tab */
   onOpenInNewTab?: (noteId: string) => void
+  /** Middle-click gesture: open the row in a background tab. */
+  onOpenInBackgroundTab?: (noteId: string) => void
   /** Called when a folder cell is clicked */
   onFolderClick?: (folderPath: string) => void
   /** Called when a tag is clicked */
@@ -289,6 +292,7 @@ export function FolderTableView({
   selectedRowIds: externalSelectedRowIds,
   onNoteOpen,
   onOpenInNewTab,
+  onOpenInBackgroundTab,
   onFolderClick,
   onTagClick,
   onTagRemove,
@@ -1267,6 +1271,9 @@ export function FolderTableView({
                     )}
                     onClick={(e) => handleRowClick(virtualRow.index, row.original.id, e)}
                     onDoubleClick={() => onNoteOpen?.(row.original.id)}
+                    onMouseDown={(e) =>
+                      handleMiddleClick(e, () => onOpenInBackgroundTab?.(row.original.id))
+                    }
                   >
                     {/* Leading per-row checkbox (reveals on hover or while a selection is active) */}
                     <td

--- a/apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx
@@ -68,6 +68,7 @@ import {
   type AppIcon
 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { handleMiddleClick } from '@/lib/middle-click'
 import { getColumnLabel } from '@/lib/contract-display-names'
 import { evaluateFormula } from '@/lib/expression-evaluator'
 import { stringifyUnknown } from '@/lib/stringify-unknown'
@@ -143,6 +144,8 @@ interface GroupedTableProps {
   onNoteOpen?: (noteId: string) => void
   /** Called when a note should be opened in a new tab */
   onOpenInNewTab?: (noteId: string) => void
+  /** Middle-click gesture: open the row in a background tab. */
+  onOpenInBackgroundTab?: (noteId: string) => void
   /** Called when a folder cell is clicked */
   onFolderClick?: (folderPath: string) => void
   /** Called when a tag is clicked */
@@ -318,6 +321,7 @@ export function GroupedTable({
   selectedRowIds: externalSelectedRowIds,
   onNoteOpen,
   onOpenInNewTab,
+  onOpenInBackgroundTab,
   onFolderClick,
   onTagClick,
   onTagRemove,
@@ -1266,6 +1270,9 @@ export function GroupedTable({
                     )}
                     onClick={(e) => handleRowClick(virtualRow.index, row.original.id, e)}
                     onDoubleClick={() => onNoteOpen?.(row.original.id)}
+                    onMouseDown={(e) =>
+                      handleMiddleClick(e, () => onOpenInBackgroundTab?.(row.original.id))
+                    }
                   >
                     {/* Leading per-row checkbox (reveals on hover or while a selection is active) */}
                     <td

--- a/apps/desktop/src/renderer/src/components/folder-view/tag-value-input.test.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/tag-value-input.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TagValueInput } from './tag-value-input'
+import type { TagSuggestion } from '@/lib/tag-suggestions'
+
+const suggestions: TagSuggestion[] = [
+  { name: 'inbox', count: 40 },
+  { name: 'work', color: 'blue', count: 30 },
+  { name: 'work/design', count: 20 },
+  { name: 'personal', count: 10 },
+  { name: 'reading', count: 5 },
+  { name: 'archive', count: 1 }
+]
+
+/** Controlled wrapper: the real caller feeds the value back on every change. */
+function Harness({ onChange }: { onChange?: (value: string) => void }): React.JSX.Element {
+  const [value, setValue] = useState('')
+  return (
+    <TagValueInput
+      value={value}
+      onChange={(next) => {
+        setValue(next)
+        onChange?.(next)
+      }}
+      suggestions={suggestions}
+      placeholder="Value"
+    />
+  )
+}
+
+const openList = (): HTMLElement => {
+  const input = screen.getByRole('combobox')
+  fireEvent.focus(input)
+  return input
+}
+
+describe('TagValueInput', () => {
+  it('offers the five most-used tags on focus and nothing before it', () => {
+    render(<Harness />)
+    expect(screen.queryByRole('listbox')).toBeNull()
+
+    openList()
+
+    expect(screen.getAllByRole('option').map((o) => o.textContent)).toEqual([
+      'inbox40',
+      'work30',
+      'work/design20',
+      'personal10',
+      'reading5'
+    ])
+  })
+
+  it('re-ranks on every keystroke', () => {
+    render(<Harness />)
+    const input = openList()
+
+    fireEvent.change(input, { target: { value: 'des' } })
+
+    expect(screen.getAllByRole('option').map((o) => o.textContent)).toEqual(['work/design20'])
+  })
+
+  it('fills the value from the highlighted tag on Enter and closes the list', () => {
+    const onChange = vi.fn()
+    render(<Harness onChange={onChange} />)
+    const input = openList()
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onChange).toHaveBeenLastCalledWith('work/design')
+    expect(input).toHaveValue('work/design')
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+
+  it('wraps the highlight upward from the first item', () => {
+    const onChange = vi.fn()
+    render(<Harness onChange={onChange} />)
+    const input = openList()
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onChange).toHaveBeenLastCalledWith('reading')
+  })
+
+  it('fills the value from a clicked tag', () => {
+    const onChange = vi.fn()
+    render(<Harness onChange={onChange} />)
+    openList()
+
+    fireEvent.click(screen.getByRole('option', { name: /personal/ }))
+
+    expect(onChange).toHaveBeenLastCalledWith('personal')
+  })
+
+  it('closes on Escape without clearing what was typed', () => {
+    render(<Harness />)
+    const input = openList()
+    fireEvent.change(input, { target: { value: 'work' } })
+
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(screen.queryByRole('listbox')).toBeNull()
+    expect(input).toHaveValue('work')
+  })
+
+  it('leaves Enter alone when no suggestion is showing', () => {
+    render(<Harness />)
+    const input = openList()
+    fireEvent.change(input, { target: { value: 'nothing-matches-this' } })
+
+    expect(screen.queryByRole('listbox')).toBeNull()
+    const enter = fireEvent.keyDown(input, { key: 'Enter' })
+
+    // Not swallowed: the filter popover still gets its Enter.
+    expect(enter).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/folder-view/tag-value-input.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/tag-value-input.tsx
@@ -1,0 +1,194 @@
+/**
+ * Tag Value Input
+ *
+ * The value field of a `tags` filter condition. It is a plain text input — the
+ * filter expression still stores a bare string — with a suggestion list over
+ * the vault's tags so the name never has to be recalled from memory: focus
+ * offers the most-used tags, every keystroke re-ranks, arrows move and Enter
+ * commits the highlighted tag into the input.
+ */
+
+import { useCallback, useId, useMemo, useRef, useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import { getTagColors, withAlpha } from '@/components/note/tags-row/tag-colors'
+import { rankTagSuggestions, type TagSuggestion } from '@/lib/tag-suggestions'
+import { useT } from '@memry/i18n/renderer'
+
+/** Most-used tags offered on focus, before anything is typed. */
+const FOCUS_LIMIT = 5
+/** Cap while searching — enough to scan, short enough to stay a menu. */
+const SEARCH_LIMIT = 8
+
+interface TagValueInputProps {
+  /** Current condition value (a bare tag string). */
+  value: string
+  /** Called on every keystroke and on suggestion pick. */
+  onChange: (value: string) => void
+  /** Vault tags to suggest; empty means the input behaves as plain text. */
+  suggestions: readonly TagSuggestion[]
+  placeholder: string
+}
+
+export function TagValueInput({
+  value,
+  onChange,
+  suggestions,
+  placeholder
+}: TagValueInputProps): React.JSX.Element {
+  const { t } = useT('notes')
+  const listId = useId()
+  const [isOpen, setIsOpen] = useState(false)
+  const [highlight, setHighlight] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const items = useMemo(
+    () => rankTagSuggestions(suggestions, value, value.trim() ? SEARCH_LIMIT : FOCUS_LIMIT),
+    [suggestions, value]
+  )
+
+  // Clamped on render rather than reset in an effect: the list changes with
+  // every keystroke, and a stale index must never point past its end.
+  const activeIndex = items.length === 0 ? -1 : Math.min(highlight, items.length - 1)
+  const showList = isOpen && items.length > 0
+
+  const commit = useCallback(
+    (tag: TagSuggestion) => {
+      onChange(tag.name)
+      // Focus first, close second: a picked-by-mouse commit refocuses the
+      // input, and that focus event asks to re-open. Closing after it means
+      // the list stays shut whichever way the tag was picked.
+      inputRef.current?.focus()
+      setIsOpen(false)
+      setHighlight(0)
+    },
+    [onChange]
+  )
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        if (items.length === 0) return
+        event.preventDefault()
+        if (!isOpen) {
+          setIsOpen(true)
+          return
+        }
+        const delta = event.key === 'ArrowDown' ? 1 : -1
+        setHighlight((current) => {
+          const next = (Math.min(current, items.length - 1) + delta + items.length) % items.length
+          return next
+        })
+        return
+      }
+
+      if (event.key === 'Enter') {
+        if (!showList || activeIndex < 0) return
+        // Stop here: the surrounding filter popover treats Enter as "done".
+        event.preventDefault()
+        event.stopPropagation()
+        commit(items[activeIndex])
+        return
+      }
+
+      if (event.key === 'Escape' && showList) {
+        // Close the list only — the filter popover stays open.
+        event.preventDefault()
+        event.stopPropagation()
+        setIsOpen(false)
+        return
+      }
+
+      if (event.key === 'Tab') setIsOpen(false)
+    },
+    [activeIndex, commit, isOpen, items, showList]
+  )
+
+  return (
+    // The list is portalled rather than absolutely positioned: this input
+    // lives inside the filter popover, whose content is `overflow-clip`, so an
+    // in-flow dropdown is cut off at the popover's edge. Anchoring it the way
+    // the sibling date picker does puts it above everything.
+    <Popover open={showList}>
+      <PopoverAnchor asChild>
+        <div className="flex-1 min-w-0">
+          <Input
+            ref={inputRef}
+            type="text"
+            role="combobox"
+            aria-label={placeholder}
+            aria-expanded={showList}
+            aria-controls={showList ? listId : undefined}
+            aria-activedescendant={
+              showList && activeIndex >= 0 ? `${listId}-${activeIndex}` : undefined
+            }
+            aria-autocomplete="list"
+            autoComplete="off"
+            value={value}
+            onChange={(event) => {
+              onChange(event.target.value)
+              setHighlight(0)
+              setIsOpen(true)
+            }}
+            onFocus={() => setIsOpen(true)}
+            onBlur={() => setIsOpen(false)}
+            onKeyDown={handleKeyDown}
+            className="h-[26px] w-full min-w-0 rounded-md border-border bg-transparent px-2 text-[11.5px] text-foreground"
+            placeholder={placeholder}
+          />
+        </div>
+      </PopoverAnchor>
+
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        // Typing is the interaction — the list must never take the caret.
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        // Keep the input focused: blur would close the list before a click
+        // lands, so the pick would never happen.
+        onMouseDown={(event) => event.preventDefault()}
+        className="max-h-56 w-[200px] overflow-y-auto p-1"
+      >
+        <ul
+          id={listId}
+          role="listbox"
+          aria-label={t('phaseF.componentsFolderViewFilterRow.tagSuggestions')}
+        >
+          {items.map((tag, index) => {
+            const colors = getTagColors(tag.color ?? '', tag.name)
+            return (
+              <li key={tag.name.toLowerCase()}>
+                <button
+                  id={`${listId}-${index}`}
+                  type="button"
+                  role="option"
+                  aria-selected={index === activeIndex}
+                  onClick={() => commit(tag)}
+                  onMouseEnter={() => setHighlight(index)}
+                  className={cn(
+                    'flex w-full items-center gap-2 rounded-sm px-1.5 py-1 text-start outline-none',
+                    index === activeIndex && 'bg-accent'
+                  )}
+                >
+                  <span
+                    className="min-w-0 truncate rounded-full px-1.5 py-0.5 text-[11px] font-medium"
+                    style={{ backgroundColor: withAlpha(colors.text, 0.12), color: colors.text }}
+                  >
+                    {tag.name}
+                  </span>
+                  <span className="ms-auto shrink-0 text-[10px] text-muted-foreground">
+                    {tag.count}
+                  </span>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export default TagValueInput

--- a/apps/desktop/src/renderer/src/lib/middle-click.ts
+++ b/apps/desktop/src/renderer/src/lib/middle-click.ts
@@ -1,0 +1,18 @@
+/**
+ * Middle-click gesture.
+ *
+ * A middle click never produces a `click` event, so "open in a background tab"
+ * has to be read off `mousedown`. `preventDefault` also suppresses Chromium's
+ * autoscroll cursor, which would otherwise latch onto the scroll container.
+ *
+ * @module lib/middle-click
+ */
+
+/** Run `open` when `event` is a middle click; ignore every other button. */
+export function handleMiddleClick(event: React.MouseEvent, open: () => void): void {
+  if (event.button !== 1) return
+  event.preventDefault()
+  open()
+}
+
+export default handleMiddleClick

--- a/apps/desktop/src/renderer/src/lib/tag-suggestions.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tag-suggestions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { rankTagSuggestions, type TagSuggestion } from './tag-suggestions'
+
+const tags: TagSuggestion[] = [
+  { name: 'work', color: 'blue', count: 12 },
+  { name: 'work/design', count: 7 },
+  { name: 'homework', count: 30 },
+  { name: 'personal', color: '#ff0000', count: 9 },
+  { name: 'projects/website', count: 4 }
+]
+
+describe('rankTagSuggestions', () => {
+  it('offers the most-used tags when nothing is typed', () => {
+    expect(rankTagSuggestions(tags, '', 3).map((t) => t.name)).toEqual([
+      'homework',
+      'work',
+      'personal'
+    ])
+  })
+
+  it('puts an exact match first, then prefixes, then leaf and substring matches', () => {
+    // `homework` has the highest count but only matches as a substring, so it
+    // must rank below every prefix match.
+    expect(rankTagSuggestions(tags, 'work', 5).map((t) => t.name)).toEqual([
+      'work',
+      'work/design',
+      'homework'
+    ])
+  })
+
+  it('finds a nested tag by its leaf segment', () => {
+    expect(rankTagSuggestions(tags, 'des', 5).map((t) => t.name)).toEqual(['work/design'])
+  })
+
+  it('ignores case and a leading hash', () => {
+    expect(rankTagSuggestions(tags, '  #PERSONAL ', 5).map((t) => t.name)).toEqual(['personal'])
+  })
+
+  it('drops non-matching tags and respects the limit', () => {
+    expect(rankTagSuggestions(tags, 'zzz', 5)).toEqual([])
+    expect(rankTagSuggestions(tags, '', 2)).toHaveLength(2)
+    expect(rankTagSuggestions(tags, '', 0)).toEqual([])
+  })
+
+  it('collapses duplicate names differing only by case and skips blanks', () => {
+    const dupes: TagSuggestion[] = [
+      { name: 'Work', count: 3 },
+      { name: 'work', count: 99 },
+      { name: '   ', count: 50 }
+    ]
+    expect(rankTagSuggestions(dupes, '', 5)).toEqual([{ name: 'Work', count: 3 }])
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/tag-suggestions.ts
+++ b/apps/desktop/src/renderer/src/lib/tag-suggestions.ts
@@ -1,0 +1,78 @@
+/**
+ * Tag suggestion ranking.
+ *
+ * Shared by the folder/tag view's filter value input: on focus it offers the
+ * most-used tags, and every keystroke re-ranks the vault's tags so a filter
+ * value never has to be typed from memory.
+ *
+ * @module lib/tag-suggestions
+ */
+
+/** A vault tag as the suggestion list needs it. */
+export interface TagSuggestion {
+  /** Full tag name, hierarchy included (e.g. `work/design`). */
+  name: string
+  /** Stored color (name or hex); empty when the tag has no definition. */
+  color?: string
+  /** Usage count across notes — the ranking's primary signal. */
+  count: number
+}
+
+/** Match quality, best first. Ties break on count, then name. */
+const TIER_EXACT = 0
+const TIER_PREFIX = 1
+const TIER_SEGMENT_PREFIX = 2
+const TIER_SUBSTRING = 3
+
+/** Where `query` matches `name`, or `null` when it does not match at all. */
+function tierFor(name: string, query: string): number | null {
+  if (name === query) return TIER_EXACT
+  if (name.startsWith(query)) return TIER_PREFIX
+  // A nested tag is found by its leaf too: "design" surfaces "work/design".
+  if (name.split('/').some((segment) => segment.startsWith(query))) return TIER_SEGMENT_PREFIX
+  if (name.includes(query)) return TIER_SUBSTRING
+  return null
+}
+
+/**
+ * Rank `tags` for `query`, best match first, capped at `limit`.
+ *
+ * An empty query is the focus case: the most-used tags, unfiltered. Otherwise
+ * only matching tags survive, ordered by how well they match and then by use.
+ * Duplicate names (same tag from two sources) collapse onto the first one.
+ */
+export function rankTagSuggestions(
+  tags: readonly TagSuggestion[],
+  query: string,
+  limit: number
+): TagSuggestion[] {
+  if (limit <= 0) return []
+
+  // `#work` and `work` are the same query — a tag pill is written both ways.
+  const normalized = query.trim().replace(/^#+/, '').toLowerCase()
+  const seen = new Set<string>()
+  const scored: Array<{ tag: TagSuggestion; tier: number; name: string }> = []
+
+  for (const tag of tags) {
+    const name = tag.name.trim()
+    if (!name) continue
+    const lower = name.toLowerCase()
+    if (seen.has(lower)) continue
+
+    const tier = normalized === '' ? TIER_EXACT : tierFor(lower, normalized)
+    if (tier === null) continue
+
+    seen.add(lower)
+    scored.push({ tag, tier, name: lower })
+  }
+
+  scored.sort((a, b) => {
+    if (a.tier !== b.tier) return a.tier - b.tier
+    if (a.tag.count !== b.tag.count) return b.tag.count - a.tag.count
+    return a.name.localeCompare(b.name)
+  })
+
+  return scored.slice(0, limit).map((entry) => entry.tag)
+}
+
+export default rankTagSuggestions

--- a/apps/desktop/src/renderer/src/pages/folder-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/folder-view.tsx
@@ -26,6 +26,7 @@ import {
   AlertDialogTitle
 } from '@/components/ui/alert-dialog'
 import { useTabs, useActiveTab } from '@/contexts/tabs'
+import type { SidebarItem } from '@/contexts/tabs/types'
 import { useOpenPage } from '@/hooks/use-open-target'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
 import { FolderTableView } from '@/components/folder-view/folder-table-view'
@@ -70,10 +71,12 @@ import {
   type FilterExpression,
   type ColumnConfig,
   type GroupByConfig,
-  type ViewScope
+  type ViewScope,
+  type NoteWithProperties
 } from '@memry/contracts/folder-view-api'
 import { createLogger } from '@/lib/logger'
 import { extractErrorMessage } from '@/lib/ipc-error'
+import type { TagSuggestion } from '@/lib/tag-suggestions'
 import { toast } from 'sonner'
 import { useT } from '@memry/i18n/renderer'
 
@@ -86,6 +89,44 @@ interface FolderViewPageProps {
 
 /** Stable empty selection, so folder scope never produces a new array identity. */
 const EMPTY_TAG_SELECTION: string[] = []
+
+/**
+ * The sidebar item a row opens as. A tag page can list tasks and inbox items
+ * beside notes, and those live on their own pages — so the row's `kind`, not
+ * the page, decides where it goes. Shared by the plain open and the
+ * middle-click background open so a row lands in the same place either way.
+ */
+function sidebarItemForRow(item: NoteWithProperties): SidebarItem {
+  const kind = item.kind ?? 'note'
+
+  if (kind === 'task') {
+    return {
+      type: 'tasks',
+      title: 'Tasks',
+      icon: 'CheckSquare',
+      path: '/tasks',
+      // No `selectedProjectId`: under tag scope a row carries no project id,
+      // only a folder name, so the Tasks page falls back to its default
+      // project scope.
+      viewState: { openTaskId: item.id, activeInternalTab: 'all', activeTab: 'all' }
+    }
+  }
+
+  if (kind === 'inbox') {
+    return {
+      type: 'inbox',
+      title: 'Inbox',
+      icon: 'Inbox',
+      path: '/inbox',
+      // Fresh `focusedAt` token so Inbox's focus effect re-fires even when the
+      // same item is opened twice in a row (it dedupes on the token) — see
+      // inbox.tsx's focus effect.
+      viewState: { focusInboxItemId: item.id, focusedAt: Date.now() }
+    }
+  }
+
+  return { type: 'note', path: item.path, entityId: item.id, title: item.title, emoji: item.emoji }
+}
 
 /**
  * Folder View Page Component
@@ -342,6 +383,13 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
     return map
   }, [allTags])
 
+  // Value suggestions for a `tags` filter condition — the same vault tags the
+  // pills are drawn from, so the dropdown's colors match the rows'.
+  const tagSuggestions = useMemo<TagSuggestion[]>(
+    () => allTags.map((tag) => ({ name: tag.tag, color: tag.color, count: tag.count })),
+    [allTags]
+  )
+
   // Tag scope's header identity — the stored tag definition (color/icon), a
   // deterministic color fallback via getTagColors (same as tag-view.tsx),
   // and the hierarchy segments for a nested tag like "araba/lastik".
@@ -387,47 +435,20 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
     (rowId: string): void => {
       const item = notes.find((n) => n.id === rowId)
       if (!item) return
-      const kind = item.kind ?? 'note'
+      openSidebarItem(sidebarItemForRow(item))
+    },
+    [notes, openSidebarItem]
+  )
 
-      if (kind === 'task') {
-        openSidebarItem({
-          type: 'tasks',
-          title: 'Tasks',
-          icon: 'CheckSquare',
-          path: '/tasks',
-          // No `selectedProjectId`: under tag scope a row carries no project
-          // id, only a folder name, so the Tasks page falls back to its
-          // default project scope.
-          viewState: {
-            openTaskId: item.id,
-            activeInternalTab: 'all',
-            activeTab: 'all'
-          }
-        })
-        return
-      }
-
-      if (kind === 'inbox') {
-        openSidebarItem({
-          type: 'inbox',
-          title: 'Inbox',
-          icon: 'Inbox',
-          path: '/inbox',
-          // Fresh `focusedAt` token so Inbox's focus effect re-fires even
-          // when the same item is opened twice in a row (it dedupes on the
-          // token) — see inbox.tsx's focus effect.
-          viewState: { focusInboxItemId: item.id, focusedAt: Date.now() }
-        })
-        return
-      }
-
-      openSidebarItem({
-        type: 'note',
-        path: item.path,
-        entityId: item.id,
-        title: item.title,
-        emoji: item.emoji
-      })
+  // Middle-click: the row's "Open in New Tab" as a gesture, in the background,
+  // exactly as the sidebar rows behave. Both scopes route through the same
+  // sidebar item as a plain open, so a tag page's task/inbox rows still land
+  // on their own pages rather than opening as a note.
+  const handleRowOpenInBackgroundTab = useCallback(
+    (rowId: string): void => {
+      const item = notes.find((n) => n.id === rowId)
+      if (!item) return
+      openSidebarItem(sidebarItemForRow(item), { inNewTab: true, inBackground: true })
     },
     [notes, openSidebarItem]
   )
@@ -1147,6 +1168,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
           <FilterBuilder
             filters={activeView?.filters as FilterExpression | undefined}
             availableProperties={availableProperties}
+            tagSuggestions={tagSuggestions}
             builtInColumns={builtInColumns}
             onFiltersChange={(...args) => void updateFilters(...args)}
             lockedCondition={
@@ -1273,6 +1295,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
               density="compact"
               tagMetaMap={tagMetaMap}
               onNoteOpen={onRowOpen}
+              onOpenInBackgroundTab={handleRowOpenInBackgroundTab}
               onTagClick={handleTagClick}
               onCreateNote={() => void handleCreateNote()}
               onClearAll={handleClearAll}
@@ -1285,6 +1308,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
               scrollKey={activeScrollKey}
               tagMetaMap={tagMetaMap}
               onNoteOpen={onRowOpen}
+              onOpenInBackgroundTab={handleRowOpenInBackgroundTab}
               onTagClick={handleTagClick}
               onCreateNote={() => void handleCreateNote()}
               onClearAll={handleClearAll}
@@ -1305,6 +1329,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
               onSelectionChange={handleSelectionChange}
               onNoteOpen={onRowOpen}
               onOpenInNewTab={handleOpenInNewTab}
+              onOpenInBackgroundTab={handleRowOpenInBackgroundTab}
               onFolderClick={handleFolderClick}
               onTagClick={handleTagClick}
               onTagRemove={handleTagRemove}
@@ -1341,6 +1366,7 @@ export function FolderViewPage({ scope }: FolderViewPageProps): React.JSX.Elemen
               onSelectionChange={handleSelectionChange}
               onNoteOpen={onRowOpen}
               onOpenInNewTab={handleOpenInNewTab}
+              onOpenInBackgroundTab={handleRowOpenInBackgroundTab}
               onFolderClick={handleFolderClick}
               onTagClick={handleTagClick}
               onTagRemove={handleTagRemove}

--- a/apps/desktop/tests/e2e/folder-view-middle-click.e2e.ts
+++ b/apps/desktop/tests/e2e/folder-view-middle-click.e2e.ts
@@ -1,0 +1,91 @@
+/**
+ * Middle-click on a folder-view / tag-page row.
+ *
+ * The sidebar rows have opened in a background tab on middle click for a
+ * while; the table these pages render did not, so the gesture died on the
+ * biggest list in the app. Driven against the real app because the whole
+ * claim is about the tab strip, which only the tab system can answer.
+ */
+
+import type { Page } from '@playwright/test'
+
+import { test, expect } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+import { SELECTORS } from './utils/electron-helpers'
+
+const UNIQUE = Date.now().toString(36)
+const TAG = `middle${UNIQUE}`
+const FOLDER = `Middle${UNIQUE}`
+
+const TAGGED_TITLE = `Tagged row ${UNIQUE}`
+const FOLDER_TITLE = `Folder row ${UNIQUE}`
+
+const tabs = (page: Page) => page.locator(SELECTORS.tab)
+const rows = (page: Page) => page.getByRole('table').locator('tbody tr')
+
+async function seedNotes(page: Page): Promise<void> {
+  const ok = await page.evaluate(
+    async ({ tag, folder, taggedTitle, folderTitle }) => {
+      const tagged = await window.api.notes.create({
+        title: taggedTitle,
+        content: 'Lives on the tag page',
+        tags: [tag]
+      })
+      const inFolder = await window.api.notes.create({
+        title: folderTitle,
+        content: 'Lives in a folder',
+        folder
+      })
+      return !!tagged?.success && !!inFolder?.success
+    },
+    { tag: TAG, folder: FOLDER, taggedTitle: TAGGED_TITLE, folderTitle: FOLDER_TITLE }
+  )
+  expect(ok).toBeTruthy()
+}
+
+async function expandSection(page: Page, prefix: string): Promise<void> {
+  const trigger = page.locator(`button[aria-label^="${prefix} section, "]`)
+  await trigger.waitFor({ state: 'visible', timeout: 20_000 })
+  if (((await trigger.getAttribute('aria-label')) ?? '').includes('collapsed')) {
+    await trigger.click()
+  }
+}
+
+/** Middle-click the row carrying `title` and assert a background tab arrived. */
+async function expectBackgroundOpen(page: Page, title: string, activeText: string): Promise<void> {
+  const before = await tabs(page).count()
+  await rows(page).filter({ hasText: title }).first().click({ button: 'middle' })
+
+  await expect.poll(async () => tabs(page).count(), { timeout: 10_000 }).toBe(before + 1)
+  await expect(page.locator(SELECTORS.tab).filter({ hasText: title }).first()).toBeVisible()
+  // Background: the page we middle-clicked from keeps focus.
+  await expect(page.locator(SELECTORS.activeTab)).toContainText(activeText)
+}
+
+test.describe('Middle-click opens a row in a background tab', () => {
+  test.beforeEach(async ({ page }) => {
+    await ready(page)
+    await seedNotes(page)
+  })
+
+  test('on a tag page', async ({ page }) => {
+    await expandSection(page, 'Tags')
+    await page.getByRole('button', { name: TAG, exact: true }).first().click()
+    await expect(page.getByRole('table')).toBeVisible({ timeout: 20_000 })
+
+    await expectBackgroundOpen(page, TAGGED_TITLE, TAG)
+  })
+
+  test('on a folder view page', async ({ page }) => {
+    await expandSection(page, 'Collections')
+    const folderRow = page.locator(`[data-tree-node-id="folder-${FOLDER}"]`)
+    await folderRow.waitFor({ state: 'visible', timeout: 20_000 })
+    // A plain click on a folder row only expands it; the folder *view* has its
+    // own affordance on the row.
+    await folderRow.hover()
+    await folderRow.getByRole('button', { name: 'Open folder view' }).click()
+    await expect(page.getByRole('table')).toBeVisible({ timeout: 20_000 })
+
+    await expectBackgroundOpen(page, FOLDER_TITLE, FOLDER)
+  })
+})

--- a/apps/desktop/tests/e2e/tag-filter-suggestions.e2e.ts
+++ b/apps/desktop/tests/e2e/tag-filter-suggestions.e2e.ts
@@ -1,0 +1,113 @@
+/**
+ * Tag suggestions in a filter's value input.
+ *
+ * A `tags contains …` condition used to demand the tag be typed from memory:
+ * the value was a bare text box with no knowledge of the vault's tags. This
+ * drives the real app because the value that matters is the one that reaches
+ * the query — a component test can prove the dropdown fills the input, not
+ * that the table behind it narrows.
+ */
+
+import type { Locator, Page } from '@playwright/test'
+
+import { test, expect } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+
+const UNIQUE = Date.now().toString(36)
+const TAG_ROOT = `suggest${UNIQUE}`
+const TAG_CHILD = `${TAG_ROOT}/design`
+
+const ROOT_ONLY_TITLE = `Root only ${UNIQUE}`
+const CHILD_TITLE = `Child tagged ${UNIQUE}`
+
+async function seedNotes(page: Page): Promise<void> {
+  const ok = await page.evaluate(
+    async ({ root, child, rootTitle, childTitle }) => {
+      const a = await window.api.notes.create({
+        title: rootTitle,
+        content: 'Only the root tag',
+        tags: [root]
+      })
+      const b = await window.api.notes.create({
+        title: childTitle,
+        content: 'Root plus the nested tag',
+        tags: [root, child]
+      })
+      return !!a?.success && !!b?.success
+    },
+    { root: TAG_ROOT, child: TAG_CHILD, rootTitle: ROOT_ONLY_TITLE, childTitle: CHILD_TITLE }
+  )
+  expect(ok).toBeTruthy()
+}
+
+async function openTagPage(page: Page, tag: string): Promise<void> {
+  const trigger = page.locator('button[aria-label^="Tags section, "]')
+  await trigger.waitFor({ state: 'visible', timeout: 20_000 })
+  if (((await trigger.getAttribute('aria-label')) ?? '').includes('collapsed')) {
+    await trigger.click()
+  }
+  const tagRow = page.getByRole('button', { name: tag, exact: true }).first()
+  await tagRow.waitFor({ state: 'visible', timeout: 20_000 })
+  await tagRow.click()
+  await expect(page.getByRole('table')).toBeVisible({ timeout: 20_000 })
+}
+
+/** Open the filter popover and add an empty `tags contains` condition. */
+async function addTagsCondition(page: Page): Promise<Locator> {
+  await page.getByRole('button', { name: 'Filter', exact: true }).first().click()
+  // Pinned by content, not by order: the suggestion list is its own popper,
+  // so `.last()` stops being the filter popover the moment it opens.
+  const popover = page
+    .locator('[data-radix-popper-content-wrapper]')
+    .filter({ has: page.getByRole('button', { name: 'Add filter' }) })
+  await popover.getByRole('button', { name: 'Add filter' }).click()
+
+  await popover.getByRole('combobox', { name: 'Property' }).click()
+  await page.getByRole('option', { name: 'Tags' }).click()
+
+  // `tags` is a multiselect, whose default operator is already `contains`.
+  await expect(popover.getByRole('combobox', { name: 'Operator' })).toContainText('contains')
+  return popover
+}
+
+const rows = (page: Page) => page.getByRole('table').locator('tbody tr')
+
+test.describe('Tag value suggestions in the filter builder', () => {
+  test.beforeEach(async ({ page }) => {
+    await ready(page)
+  })
+
+  test('focus offers vault tags, typing re-ranks, and Enter narrows the table', async ({
+    page
+  }) => {
+    await seedNotes(page)
+    await openTagPage(page, TAG_ROOT)
+
+    await expect(rows(page).filter({ hasText: ROOT_ONLY_TITLE })).toHaveCount(1)
+    await expect(rows(page).filter({ hasText: CHILD_TITLE })).toHaveCount(1)
+
+    const popover = await addTagsCondition(page)
+    const value = popover.getByRole('combobox', { name: 'Value' })
+    await value.click()
+
+    // Focus alone is enough — nothing typed yet.
+    const list = page.getByRole('listbox', { name: 'Tag suggestions' })
+    await expect(list).toBeVisible({ timeout: 10_000 })
+
+    // Every keystroke re-ranks: "design" is only the nested tag's leaf.
+    await value.fill('design')
+    await expect(list.getByRole('option')).toHaveCount(1)
+    await expect(list.getByRole('option').first()).toContainText(TAG_CHILD)
+
+    // Arrow + Enter commits the tag into the value, and the list closes.
+    await value.press('ArrowDown')
+    await value.press('Enter')
+    await expect(value).toHaveValue(TAG_CHILD)
+    await expect(list).toBeHidden()
+
+    // The filter behind it ran: only the note carrying the nested tag is left.
+    await page.keyboard.press('Escape')
+    await expect(rows(page).filter({ hasText: CHILD_TITLE })).toHaveCount(1, { timeout: 15_000 })
+    await expect(rows(page).filter({ hasText: ROOT_ONLY_TITLE })).toHaveCount(0)
+  })
+})

--- a/apps/docs/src/user-guide/folder-view.md
+++ b/apps/docs/src/user-guide/folder-view.md
@@ -49,6 +49,21 @@ A filter bar above the table accepts:
 
 Active filters show as chips you can dismiss.
 
+### Tag values suggest themselves
+
+A `Tags contains` (or `does not contain`) condition does not make you remember how a tag is
+spelled. Click into its value box and memrynote lists your five most-used tags, drawn as the
+same coloured pills you see everywhere else. Type and the list re-ranks on each keystroke,
+finding a nested tag by its last segment too — `design` surfaces `work/design`. <kbd>↑</kbd>
+and <kbd>↓</kbd> move through the list, <kbd>Enter</kbd> puts the highlighted tag in the box,
+and the table behind the popover narrows straight away.
+
+### Opening a row in a background tab
+
+Middle-click a row — in the table, list, or gallery layout — to open it in a background tab,
+the same gesture the sidebar rows support. On a tag page this follows the row's kind: a task
+row opens Tasks and an inbox row opens the Inbox, exactly as a normal click would.
+
 ## Density
 
 A density toggle in the toolbar:

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -73,6 +73,8 @@ The modifier gestures apply to those top-of-sidebar views:
 
 In the notes tree, <kbd>⌘</kbd>/<kbd>Ctrl</kbd> click selects several rows at once instead — use the context menu there.
 
+Rows in a [Folder View](/user-guide/folder-view) or on a tag page take the middle-click gesture too, opening that row in a background tab.
+
 Each copy is an independent tab: close, pin, or move one and the other stays put. Edits made in either appear in both.
 
 Whole-app views — Home, Inbox, Calendar, Tasks, Journal, Graph, and Tags — stay single-instance, since a second copy would show exactly the same thing. Their rows leave **Open in New Tab** out of the menu rather than offer a command that would only refocus the tab you already have, and the modifier gestures focus that tab instead of duplicating it.

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -679,7 +679,8 @@
       "placeholderProperty": "Property",
       "placeholderOperator": "Operator",
       "placeholderValue": "Value",
-      "removeFilter": "Remove filter"
+      "removeFilter": "Remove filter",
+      "tagSuggestions": "Tag suggestions"
     },
     "componentsFolderViewFolderTableView": {
       "notesTable": "Notes table",


### PR DESCRIPTION
## Summary

Two gaps on the folder / tag page, both on top of #2154.

**1. A `Tags` filter value no longer has to be typed from memory.** Picking `Tags` + `contains` / `does not contain` used to leave a bare text box that knew nothing about the vault's tags. Now:

- Focusing the value lists the **five most-used tags**, drawn as the same coloured pills the rows and sidebar use (`getTagColors` + `withAlpha`), each with its usage count.
- Every keystroke re-ranks: exact → prefix → nested leaf (`design` finds `work/design`) → substring, ties broken by count. A leading `#` and case are ignored.
- <kbd>↑</kbd>/<kbd>↓</kbd> move (wrapping), <kbd>Enter</kbd> puts the highlighted tag in the box, <kbd>Esc</kbd> closes only the list (the filter popover stays), clicking a row picks it. The query behind the popover re-runs immediately, so the table narrows as the tag lands.

**2. Middle-click on a row opens it in a background tab** — table, grouped, list and gallery layouts, on both the folder view and a tag page. The sidebar rows have supported this for a while; the biggest list in the app did not.

### Design decisions

- **The suggestion list is portalled.** An in-flow absolute dropdown is cut off: the filter popover's content is `overflow-clip`. It now anchors through `PopoverAnchor`/`PopoverContent`, the same nesting the sibling date-picker in this row already does. (Caught by a screenshot of the real app, not by a unit test.)
- **Only the built-in `tags` column gets suggestions.** A custom `multiselect` property has its own option set; vault tags would be the wrong list.
- **Ranking lives in `lib/tag-suggestions.ts`, not the component**, so the ordering rules are testable without a DOM.
- **One row-open path.** `folder-view.tsx` grew a `sidebarItemForRow(row)` that both the plain open and the middle-click open route through, so a tag page's task row still opens Tasks and its inbox row still opens the Inbox. The gesture is just `openSidebarItem(item, { inNewTab: true, inBackground: true })` — it reuses the existing feature-flag redirect and dedup handling rather than re-implementing them.
- **`handleMiddleClick` is shared** (`lib/middle-click.ts`): four call sites need identical behaviour, and both halves matter — middle never fires `click`, and `preventDefault` is what stops Chromium's autoscroll cursor latching onto the scroll container.
- **Accessibility fallout fixed on the way:** the icon-only Filter button and the property/operator selects had no accessible name at all; they now carry one (the same strings the tooltip/placeholder show).

### Backward compatibility

No contract, schema, settings or persisted-state change. Every new prop is optional: a view rendered without `onOpenInBackgroundTab` behaves exactly as before, and `FilterBuilder`/`FilterRow` without `tagSuggestions` keep the plain text value input.

## Test plan

- `pnpm lint` — 0 errors (1 pre-existing warning in `vault-switcher.tsx`)
- `pnpm typecheck` — 19/19 (incl. `check:contracts`, `check:architecture`, `ipc:check`)
- `pnpm --filter @memry/desktop i18n:check` — pass
- `pnpm docs:impact --base origin/main --strict` + `pnpm docs:build` — pass
- Renderer suites for the touched area: 18 files / 155 tests pass
- New unit coverage: `tag-suggestions.test.ts` (ranking tiers, nested leaf, `#`/case, dedupe, limits), `tag-value-input.test.tsx` (focus list, per-keystroke re-rank, arrow+Enter commit, wrap, click commit, Esc keeps the typed text, Enter not swallowed when nothing is showing), plus middle-click regressions in `folder-table-view.test.tsx` for the table and the grouped table (left button does nothing, default prevented).
- New E2E against the real app, both pass locally:
  - `tag-filter-suggestions.e2e.ts` — focus offers vault tags, typing `design` leaves only `work/design`, ↓+Enter fills the value, and the table drops the note that lacks the tag.
  - `folder-view-middle-click.e2e.ts` — middle-click adds exactly one tab and leaves focus where it was, on a tag page and on a folder view page.

Note for reviewers running things locally: `pnpm typecheck` and `rebuild:electron` need Node 24 (the repo's `.nvmrc`); Node 26 fails on `--experimental-transform-types`.

## Release note

Filter by tag without remembering how it is spelled — a `Tags` filter now suggests your most-used tags as you type — and middle-click any row in a folder or tag view to open it in a background tab.
