### PR TITLE
feat(desktop): navigate the vault switcher with the arrow keys

### DIFF
--- a/apps/desktop/src/renderer/src/components/ui/picker/index.ts
+++ b/apps/desktop/src/renderer/src/components/ui/picker/index.ts
@@ -24,5 +24,6 @@ export const Picker = Object.assign(PickerRoot, {
 })
 
 export { usePickerSearch } from './use-picker-search'
+export { PICKER_ROW_SELECTOR } from './picker-content'
 export { usePickerContext } from './types'
 export type { PickerMode, PickerIndicator } from './types'

--- a/apps/desktop/src/renderer/src/components/ui/picker/picker-content.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/picker/picker-content.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
 import { Picker } from './index'
 
 /**
@@ -101,5 +102,110 @@ describe('PickerList', () => {
     const list = screen.getByRole('listbox')
     expect(list.className).toContain('overflow-y-auto')
     expect(list.className).toContain('min-h-0')
+  })
+})
+
+describe('PickerContent keyboard navigation', () => {
+  /**
+   * Radix focuses the first row on open and loops Tab, but nothing moves focus
+   * on Arrow keys — a picker opened from the keyboard (⌘⇧O on the vault
+   * switcher) could only ever activate that first row. Rows here cover both
+   * shapes a list carries: `Picker.Item`s and a row the call site renders
+   * itself, the way the vault switcher renders its vaults.
+   */
+  const renderNavigable = (
+    onValueChange = vi.fn(),
+    contentProps: Partial<React.ComponentProps<typeof Picker.Content>> = {}
+  ): { rows: HTMLElement[]; content: HTMLElement; search: HTMLElement } => {
+    render(
+      <Picker defaultOpen onValueChange={onValueChange}>
+        <Picker.Trigger>trigger</Picker.Trigger>
+        <Picker.Content data-testid="content" {...contentProps}>
+          <Picker.Search placeholder="search" />
+          <Picker.List>
+            <Picker.Item value="one" label="one" />
+            <Picker.Item value="two" label="two" />
+            <button type="button" onClick={() => onValueChange('own-row')}>
+              own row
+            </button>
+            <Picker.Item value="off" label="off" disabled />
+          </Picker.List>
+        </Picker.Content>
+      </Picker>
+    )
+    const content = screen.getByTestId('content')
+    return {
+      content,
+      search: screen.getByPlaceholderText('search'),
+      rows: ['one', 'two', 'own row'].map((label) => screen.getByText(label).closest('button')!)
+    }
+  }
+
+  it('walks the rows on ArrowDown and wraps at the end', () => {
+    const { content, rows } = renderNavigable()
+    rows[0].focus()
+
+    fireEvent.keyDown(content, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(rows[1])
+
+    // The call site's own row is reachable too, not just `Picker.Item`s.
+    fireEvent.keyDown(content, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(rows[2])
+
+    // A disabled row is skipped rather than parking focus on a dead end.
+    fireEvent.keyDown(content, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(rows[0])
+  })
+
+  it('walks backwards on ArrowUp and wraps at the top', () => {
+    const { content, rows } = renderNavigable()
+    rows[0].focus()
+
+    fireEvent.keyDown(content, { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(rows[2])
+
+    fireEvent.keyDown(content, { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(rows[1])
+  })
+
+  it('enters the list from the content itself, where Radix parks focus', () => {
+    const { content, rows } = renderNavigable()
+    content.focus()
+
+    fireEvent.keyDown(content, { key: 'ArrowDown' })
+
+    expect(document.activeElement).toBe(rows[0])
+  })
+
+  it('activates the focused row on Enter', async () => {
+    const onValueChange = vi.fn()
+    const { content, rows } = renderNavigable(onValueChange)
+    rows[0].focus()
+
+    fireEvent.keyDown(content, { key: 'ArrowDown' })
+    await userEvent.keyboard('{Enter}')
+
+    expect(onValueChange).toHaveBeenCalledWith('two')
+  })
+
+  it('leaves the Arrow keys to the caret while the search field has focus', () => {
+    const { search } = renderNavigable()
+    search.focus()
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+
+    expect(document.activeElement).toBe(search)
+  })
+
+  it('still runs a call site handler, and lets it preempt the navigation', () => {
+    // `inline-priority-popover` binds digit shortcuts on `Picker.Content`.
+    const onKeyDown = vi.fn((e: React.KeyboardEvent) => e.preventDefault())
+    const { content, rows } = renderNavigable(vi.fn(), { onKeyDown })
+    rows[0].focus()
+
+    fireEvent.keyDown(content, { key: 'ArrowDown' })
+
+    expect(onKeyDown).toHaveBeenCalled()
+    expect(document.activeElement).toBe(rows[0])
   })
 })

--- a/apps/desktop/src/renderer/src/components/ui/picker/picker-content.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/picker/picker-content.tsx
@@ -7,10 +7,31 @@ export interface PickerContentProps extends React.ComponentPropsWithoutRef<typeo
   width?: 'auto' | 'trigger' | number
 }
 
+/**
+ * Rows a keyboard user can land on: every enabled button inside a
+ * `Picker.List`, whether it came from `Picker.Item` or from a call site that
+ * renders its own row (the vault switcher does). Secondary affordances inside a
+ * row — the vault switcher's remove and delete controls — are
+ * `span[role="button"]` and stay on the Tab path only, so Arrow keys walk rows
+ * rather than stopping inside one.
+ *
+ * Exported so a call site that wants to open on a specific row (the vault
+ * switcher opens on the active vault) picks rows the same way this file does.
+ */
+export const PICKER_ROW_SELECTOR = '[data-slot="picker-list"] button:not([disabled])'
+
+/** Arrow keys belong to the caret while a text field owns them. */
+function ownsArrowKeys(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.isContentEditable) return true
+  const tag = target.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+}
+
 export const PickerContent = React.forwardRef<
   React.ComponentRef<typeof PopoverContent>,
   PickerContentProps
->(({ width, className, children, ...props }, ref) => {
+>(({ width, className, children, onKeyDown, ...props }, ref) => {
   const { contentId } = usePickerContext()
   const widthClass =
     width === 'auto'
@@ -20,6 +41,34 @@ export const PickerContent = React.forwardRef<
         : typeof width === 'number'
           ? undefined
           : 'w-72'
+
+  // Radix focuses the first row when the popover opens and loops Tab, but
+  // nothing moves focus on Arrow keys — so a picker opened from the keyboard
+  // (⌘⇧O on the vault switcher) could only ever activate that first row. Roving
+  // focus over the list's rows makes Up/Down walk them; Enter and Space then
+  // activate the focused row natively, no extra key handling needed.
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    onKeyDown?.(event)
+    if (event.defaultPrevented) return
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+    if (ownsArrowKeys(event.target)) return
+
+    const rows = Array.from(event.currentTarget.querySelectorAll<HTMLElement>(PICKER_ROW_SELECTOR))
+    if (rows.length === 0) return
+    event.preventDefault()
+
+    const step = event.key === 'ArrowDown' ? 1 : -1
+    const active = document.activeElement
+    const current = active instanceof HTMLElement ? rows.indexOf(active) : -1
+    const next =
+      current === -1
+        ? step === 1
+          ? 0
+          : rows.length - 1
+        : (current + step + rows.length) % rows.length
+
+    rows[next]?.focus()
+  }
 
   return (
     <PopoverContent
@@ -38,6 +87,7 @@ export const PickerContent = React.forwardRef<
       )}
       style={typeof width === 'number' ? { width: `${width}px` } : undefined}
       onClick={(e) => e.stopPropagation()}
+      onKeyDown={handleKeyDown}
       {...props}
     >
       <div className="flex flex-col min-h-0 text-[13px] leading-4 [font-synthesis:none]">

--- a/apps/desktop/src/renderer/src/components/ui/picker/picker-item.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/picker/picker-item.tsx
@@ -62,7 +62,9 @@ export const PickerItem = React.forwardRef<HTMLButtonElement, PickerItemProps>(
         data-slot="picker-item"
         className={cn(
           'flex items-center rounded-[5px] py-1.5 px-2 gap-2 transition-colors',
-          'hover:bg-accent focus:outline-none',
+          // Arrow-key navigation (see `picker-content.tsx`) moves focus between
+          // rows, so a focused row has to read as focused.
+          'hover:bg-accent focus:outline-none focus-visible:bg-accent focus-visible:ring-1 focus-visible:ring-ring',
           isSelected && !indicatorColor && 'bg-accent',
           destructive && 'text-destructive focus:text-destructive',
           className
@@ -96,16 +98,16 @@ export const PickerItem = React.forwardRef<HTMLButtonElement, PickerItemProps>(
           )}
         </span>
 
-        {trailing && <span className="shrink-0 ml-auto">{trailing}</span>}
+        {trailing && <span className="shrink-0 ms-auto">{trailing}</span>}
 
         {shortcut && (
-          <kbd className="ml-auto shrink-0 text-[11px] text-muted-foreground/50 font-mono">
+          <kbd className="ms-auto shrink-0 text-[11px] text-muted-foreground/50 font-mono">
             {shortcut}
           </kbd>
         )}
 
         {indicator === 'check' && isSelected && (
-          <CheckMark color={indicatorColor} className="ml-auto" />
+          <CheckMark color={indicatorColor} className="ms-auto" />
         )}
       </button>
     )

--- a/apps/desktop/src/renderer/src/components/ui/picker/picker-item.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/picker/picker-item.tsx
@@ -63,8 +63,9 @@ export const PickerItem = React.forwardRef<HTMLButtonElement, PickerItemProps>(
         className={cn(
           'flex items-center rounded-[5px] py-1.5 px-2 gap-2 transition-colors',
           // Arrow-key navigation (see `picker-content.tsx`) moves focus between
-          // rows, so a focused row has to read as focused.
-          'hover:bg-accent focus:outline-none focus-visible:bg-accent focus-visible:ring-1 focus-visible:ring-ring',
+          // rows, so the focused row carries the same tint hover uses — one
+          // highlighted row, no ring to collide with the popover edge.
+          'hover:bg-accent focus:outline-none focus-visible:bg-accent',
           isSelected && !indicatorColor && 'bg-accent',
           destructive && 'text-destructive focus:text-destructive',
           className

--- a/apps/desktop/src/renderer/src/components/vault-switcher.shortcut.test.tsx
+++ b/apps/desktop/src/renderer/src/components/vault-switcher.shortcut.test.tsx
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, act, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import React from 'react'
 
@@ -51,11 +52,35 @@ vi.mock('@/components/ui/picker', async () => {
     )
   }
   Picker.Trigger = ({ children }: { children: ReactNode }) => <>{children}</>
-  Picker.Content = ({ children }: { children: ReactNode }) => {
+  /**
+   * Radix dispatches a cancelable event on the content container before it
+   * auto-focuses, which is the seam the component uses to open on the active
+   * vault instead of the first row. Reproduce exactly that: dispatch once on
+   * open, and honour `preventDefault`.
+   */
+  Picker.Content = ({
+    children,
+    onOpenAutoFocus
+  }: {
+    children: ReactNode
+    onOpenAutoFocus?: (event: Event) => void
+  }) => {
     const { open, onOpenChange } = React.useContext(OpenContext)
+    const ref = React.useRef<HTMLDivElement>(null)
+
+    React.useEffect(() => {
+      const content = ref.current
+      if (!open || !content || !onOpenAutoFocus) return
+      const listener = onOpenAutoFocus as EventListener
+      content.addEventListener('autoFocusOnMount', listener)
+      content.dispatchEvent(new CustomEvent('autoFocusOnMount', { cancelable: true }))
+      content.removeEventListener('autoFocusOnMount', listener)
+    }, [open, onOpenAutoFocus])
+
     if (!open) return null
     return (
       <div
+        ref={ref}
         data-testid="vault-picker"
         onKeyDown={(e) => {
           if (e.key === 'Escape') onOpenChange(false)
@@ -65,7 +90,9 @@ vi.mock('@/components/ui/picker', async () => {
       </div>
     )
   }
-  Picker.List = ({ children }: { children: ReactNode }) => <div>{children}</div>
+  Picker.List = ({ children }: { children: ReactNode }) => (
+    <div data-slot="picker-list">{children}</div>
+  )
   Picker.Separator = () => <hr />
   Picker.Empty = ({ message }: { message: string }) => <div>{message}</div>
   Picker.Item = ({ value, label }: { value: string; label: string }) => {
@@ -76,7 +103,8 @@ vi.mock('@/components/ui/picker', async () => {
       </button>
     )
   }
-  return { Picker }
+  // Same string the real module exports; the component uses it to pick rows.
+  return { Picker, PICKER_ROW_SELECTOR: '[data-slot="picker-list"] button:not([disabled])' }
 })
 
 vi.mock('@memry/i18n/renderer', () => ({
@@ -217,6 +245,32 @@ describe('VaultSwitcher shortcut opening', () => {
     act(() => requestVaultSwitcherOpen())
 
     fireEvent.click(screen.getByText('Old'))
+
+    expect(mocks.switchVault).toHaveBeenCalledWith('/vaults/Old')
+  })
+
+  it('opens focused on the active vault, so the arrow keys start where the user is', () => {
+    render(<VaultSwitcher />)
+
+    act(() => requestVaultSwitcherOpen())
+
+    const activeRow = within(screen.getByTestId('vault-picker'))
+      .getByText('Active')
+      .closest('button')
+    expect(document.activeElement).toBe(activeRow)
+  })
+
+  it('switches the vault on Enter over a focused row', async () => {
+    render(<VaultSwitcher />)
+    act(() => requestVaultSwitcherOpen())
+
+    // Arrow-key movement between rows lives in `ui/picker/picker-content.tsx`;
+    // what matters here is that landing on a row and pressing Enter switches.
+    const row = within(screen.getByTestId('vault-picker'))
+      .getByText('Old')
+      .closest('button') as HTMLButtonElement
+    row.focus()
+    await userEvent.keyboard('{Enter}')
 
     expect(mocks.switchVault).toHaveBeenCalledWith('/vaults/Old')
   })

--- a/apps/desktop/src/renderer/src/components/vault-switcher.tsx
+++ b/apps/desktop/src/renderer/src/components/vault-switcher.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { Plus, Check, Loader2, X, Cloud, Trash2 } from '@/lib/icons'
 
-import { Picker } from '@/components/ui/picker'
+import { Picker, PICKER_ROW_SELECTOR } from '@/components/ui/picker'
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -117,6 +117,22 @@ export function VaultSwitcher() {
     [switchVault]
   )
 
+  // Radix's own auto-focus takes the first row. Open on the active vault
+  // instead, so ⌘⇧O lands where the user already is and Up/Down (handled in
+  // `ui/picker/picker-content.tsx`) walks out from there.
+  const handleOpenAutoFocus = useCallback((event: Event) => {
+    const content = event.currentTarget
+    if (!(content instanceof HTMLElement)) return
+
+    const target =
+      content.querySelector<HTMLElement>('[data-active-vault="true"]') ??
+      content.querySelector<HTMLElement>(PICKER_ROW_SELECTOR)
+    if (!target) return
+
+    event.preventDefault()
+    target.focus()
+  }, [])
+
   const handleSignIn = useCallback(() => {
     setOpen(false)
     openSettings('account')
@@ -192,6 +208,7 @@ export function VaultSwitcher() {
           </Picker.Trigger>
           <Picker.Content
             width="auto"
+            onOpenAutoFocus={handleOpenAutoFocus}
             onCloseAutoFocus={(e) => e.preventDefault()}
             className="min-w-56"
             align="start"
@@ -207,8 +224,12 @@ export function VaultSwitcher() {
                       key={vault.path}
                       type="button"
                       onClick={() => !isActive && void handleSwitchVault(vault.path)}
+                      data-active-vault={isActive ? 'true' : undefined}
                       className={cn(
                         'group/vault flex w-full items-center gap-2.5 rounded-[5px] px-2 py-1.5 transition-colors',
+                        // Arrow keys walk these rows (see `picker-content.tsx`),
+                        // so a keyboard-focused row has to be visible.
+                        'focus:outline-none focus-visible:bg-accent focus-visible:ring-1 focus-visible:ring-ring',
                         isActive ? 'bg-accent' : 'hover:bg-accent cursor-pointer'
                       )}
                     >
@@ -283,7 +304,7 @@ export function VaultSwitcher() {
                         setOpen(false)
                         setVaultToDownload(vault)
                       }}
-                      className="flex w-full items-center gap-2.5 rounded-[5px] px-2 py-1.5 hover:bg-accent transition-colors cursor-pointer"
+                      className="flex w-full items-center gap-2.5 rounded-[5px] px-2 py-1.5 hover:bg-accent transition-colors cursor-pointer focus:outline-none focus-visible:bg-accent focus-visible:ring-1 focus-visible:ring-ring"
                     >
                       <Cloud className="size-3.5 shrink-0 text-muted-foreground" />
                       <span className="flex-1 truncate text-start text-muted-foreground">
@@ -336,7 +357,7 @@ export function VaultSwitcher() {
                   <button
                     type="button"
                     onClick={handleSignIn}
-                    className="flex w-full items-center gap-2.5 rounded-[5px] px-2 py-1.5 hover:bg-accent transition-colors cursor-pointer"
+                    className="flex w-full items-center gap-2.5 rounded-[5px] px-2 py-1.5 hover:bg-accent transition-colors cursor-pointer focus:outline-none focus-visible:bg-accent focus-visible:ring-1 focus-visible:ring-ring"
                   >
                     <Cloud className="size-3.5 text-sidebar-terracotta" />
                     <span className="text-sidebar-terracotta font-medium">

--- a/apps/desktop/src/renderer/src/components/vault-switcher.tsx
+++ b/apps/desktop/src/renderer/src/components/vault-switcher.tsx
@@ -227,10 +227,14 @@ export function VaultSwitcher() {
                       data-active-vault={isActive ? 'true' : undefined}
                       className={cn(
                         'group/vault flex w-full items-center gap-2.5 rounded-[5px] px-2 py-1.5 transition-colors',
-                        // Arrow keys walk these rows (see `picker-content.tsx`),
-                        // so a keyboard-focused row has to be visible.
-                        'focus:outline-none focus-visible:bg-accent focus-visible:ring-1 focus-visible:ring-ring',
-                        isActive ? 'bg-accent' : 'hover:bg-accent cursor-pointer'
+                        // Arrow keys walk these rows (see `picker-content.tsx`).
+                        // The tinted row IS the cursor — hover and keyboard
+                        // focus share it, and the active vault is marked by its
+                        // check and weight instead, so exactly one row ever
+                        // reads as highlighted. A ring here would collide with
+                        // the popover edge and the row below it.
+                        'focus:outline-none focus-visible:bg-accent',
+                        isActive ? 'cursor-default' : 'hover:bg-accent cursor-pointer'
                       )}
                     >
                       <Check
@@ -304,7 +308,7 @@ export function VaultSwitcher() {
                         setOpen(false)
                         setVaultToDownload(vault)
                       }}
-                      className="flex w-full items-center gap-2.5 rounded-[5px] px-2 py-1.5 hover:bg-accent transition-colors cursor-pointer focus:outline-none focus-visible:bg-accent focus-visible:ring-1 focus-visible:ring-ring"
+                      className="flex w-full items-center gap-2.5 rounded-[5px] px-2 py-1.5 hover:bg-accent transition-colors cursor-pointer focus:outline-none focus-visible:bg-accent"
                     >
                       <Cloud className="size-3.5 shrink-0 text-muted-foreground" />
                       <span className="flex-1 truncate text-start text-muted-foreground">
@@ -357,7 +361,7 @@ export function VaultSwitcher() {
                   <button
                     type="button"
                     onClick={handleSignIn}
-                    className="flex w-full items-center gap-2.5 rounded-[5px] px-2 py-1.5 hover:bg-accent transition-colors cursor-pointer focus:outline-none focus-visible:bg-accent focus-visible:ring-1 focus-visible:ring-ring"
+                    className="flex w-full items-center gap-2.5 rounded-[5px] px-2 py-1.5 hover:bg-accent transition-colors cursor-pointer focus:outline-none focus-visible:bg-accent"
                   >
                     <Cloud className="size-3.5 text-sidebar-terracotta" />
                     <span className="text-sidebar-terracotta font-medium">

--- a/apps/desktop/tests/e2e/switch-vault-shortcut.e2e.ts
+++ b/apps/desktop/tests/e2e/switch-vault-shortcut.e2e.ts
@@ -34,6 +34,35 @@ test.describe('Switch vault shortcut', () => {
     await expect(picker(page)).toHaveCount(0)
   })
 
+  test('walks the vault list with the arrow keys', async ({ page }) => {
+    await page.keyboard.press(SWITCH_VAULT)
+
+    const content = picker(page).first()
+    await expect(content).toBeVisible()
+
+    // Opens on the active vault, so the first row a keyboard user sees is the
+    // one they are in.
+    await expect(content.locator('[data-active-vault="true"]')).toBeFocused()
+
+    const rows = content.locator('[data-slot="picker-list"] button:not([disabled])')
+    const rowCount = await rows.count()
+
+    await page.keyboard.press('ArrowDown')
+    // One vault plus "Open vault" is the floor, so there is always a next row;
+    // with a single row the wrap lands back on it.
+    const focusedAfterDown = content.locator(':focus')
+    await expect(focusedAfterDown).toHaveCount(1)
+    if (rowCount > 1) {
+      await expect(content.locator('[data-active-vault="true"]')).not.toBeFocused()
+    }
+
+    await page.keyboard.press('ArrowUp')
+    await expect(content.locator('[data-active-vault="true"]')).toBeFocused()
+
+    await page.keyboard.press('Escape')
+    await expect(picker(page)).toHaveCount(0)
+  })
+
   test('stays inert while the note editor owns the chord', async ({ page }) => {
     const editor = page.locator('[contenteditable="true"]').first()
     if ((await editor.count()) === 0) test.skip(true, 'No editor surface on the current view')

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -14,7 +14,7 @@ Default shortcuts. Entries in the Navigation, Tabs, and View categories are rebi
 | Open settings         | <kbd>⌘</kbd>+<kbd>,</kbd>                              |
 | Switch vault          | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>O</kbd>                 |
 
-> **Switch vault** opens the vault switcher in the sidebar footer from anywhere — if the sidebar is hidden it slides open for the duration, and <kbd>Esc</kbd> closes the switcher and puts the sidebar back without changing vaults. Like the other app shortcuts it stands down while you are typing in a field or in the note editor.
+> **Switch vault** opens the vault switcher in the sidebar footer from anywhere — if the sidebar is hidden it slides open for the duration, and <kbd>Esc</kbd> closes the switcher and puts the sidebar back without changing vaults. It opens on the vault you are in: <kbd>↓</kbd> and <kbd>↑</kbd> move through the list (wrapping at either end) and <kbd>Enter</kbd> switches to the highlighted vault, so a switch never needs the mouse. Like the other app shortcuts it stands down while you are typing in a field or in the note editor.
 
 > Hold <kbd>⌘</kbd> (<kbd>Ctrl</kbd> on Windows / Linux) to reveal the section numbers on the sidebar icons, then press the number to jump — <kbd>⌘</kbd>+<kbd>1</kbd> opens Home, <kbd>⌘</kbd>+<kbd>2</kbd> Inbox, and so on. Numbers follow the sidebar's visible top-to-bottom order (Home is always 1), so they shift if you hide a section. This shortcut works everywhere, including inside the editor, and is fixed rather than rebindable.
 


### PR DESCRIPTION
## Summary

Follow-up to #2160. `Cmd/Ctrl+Shift+O` opened the sidebar's vault switcher, but the picker was keyboard-dead once open: Radix focuses the first row and loops Tab, and nothing moved focus on Arrow keys — so Up/Down did nothing and Enter could only ever activate that first row. A vault switch still needed the mouse.

- `Picker.Content` now owns roving focus over its list's rows (`[data-slot="picker-list"] button:not([disabled])`), so `↓`/`↑` walk them and wrap at either end. Enter and Space activate the focused row natively — no extra key handling, and the existing `onClick` path stays the single way a vault switch happens.
- The handler lives on `Picker.Content`, not `Picker.List`, because Radix parks focus on the content element: a keydown there never reaches the list below it.
- A call site's own `onKeyDown` runs first and can preempt the navigation (`inline-priority-popover`'s digit shortcuts keep working), and Arrow keys stay with the caret while an input, textarea, select, or contenteditable owns them — so the search-bearing pickers behave exactly as before.
- Rows now read as focused by carrying the same tint hover uses — the tinted row IS the cursor, the way a native menu behaves. They had no focus affordance at all, so roving focus would have been invisible. A ring was tried first and rejected: it draws outside the row, so with the list's padding it collided with the popover border and the row below it. In the vault switcher the active vault therefore drops that tint (its check mark and weight already mark it), so only ever one row reads as highlighted.
- The vault switcher opens on the **active** vault instead of Radix's first-row default (`onOpenAutoFocus` + `data-active-vault`), so the chord lands where the user already is and `↓`/`↑` walk out from there. Enter on the active row is a no-op, the way a native select behaves.
- `ml-auto` → `ms-auto` in `picker-item.tsx`: the renderer RTL guard fires on any file the commit touches.

Deliberately at the primitive rather than in `vault-switcher.tsx`: the listbox owns option navigation, every other picker gets the same behaviour, and there is one definition of "what is a row" (`PICKER_ROW_SELECTOR`, exported so the switcher's open-focus picks rows identically).

## Release note

The vault switcher is now fully keyboard-driven: Cmd+Shift+O opens it on the vault you are in, the arrow keys move through the list, and Enter switches.

## Test plan

- **Verified against the running app** (dev build driven over CDP, two vaults registered): the chord opens with `focusedIndex` on the active vault and `isActiveVault: true`; `↓` moves to the next row, `↑` returns; `↑` then `Enter` switched `currentVault` to the other vault and closed the picker. The focus ring resolves in computed style (`rgb(155,154,151) 0 0 0 1px`).
- `picker-content.test.tsx` +6, against the real Radix popover: ArrowDown/ArrowUp walk and wrap, disabled rows are skipped, a call-site row (the shape the vault switcher uses) is reachable, focus enters the list from the content element, Enter activates the focused row (user-event), the search field keeps its Arrow keys, and a call-site handler runs and can preempt.
- `vault-switcher.shortcut.test.tsx` +2: opens focused on the active vault, and Enter over a focused row calls `switchVault`. The picker mock gained Radix's cancelable open-autofocus seam.
- `tests/e2e/switch-vault-shortcut.e2e.ts`: new arrow-walk test. Local Playwright is broken on this machine — the pre-existing test in this same file also fails at `ready(page)` — so this one relies on CI.
- Full renderer suite: 409 failures, **identical to the count on HEAD without this branch** (stashed baseline; they are a pre-existing `localStorage`-undefined environment problem on this machine), with the 8 new tests passing on top.
- `pnpm lint` (0 errors), `typecheck:web`, `typecheck:test`, `check:architecture`, `docs:impact --base origin/main --strict`, `docs:build`, `git diff --check` — clean.
- Docs: the switch-vault note in `keyboard-shortcuts.md` now states the arrow/Enter behaviour. The follow-up focus-style commit is visual only — the documented behaviour is unchanged — so it carries `MEMRY_DOCS_IMPACT_SKIP=1`.

