### PR TITLE
feat(desktop): move NSIS installs to Velopack on the next update

### DIFF
--- a/.github/workflows/velopack-smoke.yml
+++ b/.github/workflows/velopack-smoke.yml
@@ -3,6 +3,10 @@ name: Velopack Windows smoke
 # Proves the Velopack Windows path on a real Windows box: the signed Setup.exe
 # installs silently, the install layout is what the updater expects, and
 # Update.exe applies a newer package in place while Defender is running.
+#
+# The second job proves the NSIS -> Velopack hand-off: an install made by the
+# older NSIS installer is removed and replaced by the Velopack install without
+# a gap, with the Start menu shortcut back in place and the app running.
 
 on:
   workflow_dispatch:
@@ -19,6 +23,18 @@ on:
       update_tag:
         description: Release tag holding that nupkg. Defaults to release_tag.
         required: false
+      nsis_release_tag:
+        description: Release tag holding the NSIS *-setup.exe used as the "existing install" fixture
+        required: false
+        default: v2026-09-10
+      run_cli_migration:
+        description: >-
+          Drive the hand-off through `Memrynote.exe --cli migrate-installer` from the NSIS
+          install instead of running the generated script standalone. Only meaningful once
+          nsis_release_tag points at a release whose NSIS build contains the hand-off code.
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   # read, not write: the release script dispatches this against a release it has
@@ -135,4 +151,135 @@ jobs:
           path: |
             setup.log
             ${{ env.LOCALAPPDATA }}\MemryNote\*.log
+          if-no-files-found: ignore
+
+  migrate:
+    name: NSIS install hands off to Velopack
+    runs-on: windows-2022
+    timeout-minutes: 30
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      NSIS_RELEASE_TAG: ${{ inputs.nsis_release_tag }}
+      RUN_CLI_MIGRATION: ${{ inputs.run_cli_migration }}
+      # electron-builder keys the per-user uninstall entry by UUID v5 of the appId
+      # (com.memrynote.memry) under its own namespace, not by the appId itself.
+      NSIS_UNINSTALL_KEY: HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\c72afc79-ad45-5346-bedb-8907a549c673
+    steps:
+      # The checkout is only for apps/desktop/scripts/installer-handoff-script.mjs,
+      # which renders the hand-off script from the same function the app uses. It
+      # has no dependencies, so there is no pnpm install here.
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Download installers
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          New-Item -ItemType Directory -Force nsis, assets | Out-Null
+          gh release download $env:NSIS_RELEASE_TAG --repo "${{ github.repository }}" -D nsis `
+            --pattern '*-setup.exe'
+          gh release download $env:RELEASE_TAG --repo "${{ github.repository }}" -D assets `
+            --pattern 'MemryNote-win-Setup.exe'
+          Get-ChildItem nsis, assets | Format-Table Name, Length
+          $nsis = Get-ChildItem nsis -Filter '*-setup.exe' | Select-Object -First 1
+          if (-not $nsis) { throw "no *-setup.exe on $env:NSIS_RELEASE_TAG" }
+          "NSIS_INSTALLER=$($nsis.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Setup.exe is Authenticode-signed by the Certum certificate
+        shell: pwsh
+        run: |
+          $sig = Get-AuthenticodeSignature .\assets\MemryNote-win-Setup.exe
+          $sig | Format-List Status, StatusMessage
+          if ($sig.Status -ne 'Valid') { throw "Setup.exe signature status: $($sig.Status)" }
+          if ($sig.SignerCertificate.Subject -notmatch 'Kaan Karaca') { throw "unexpected signer: $($sig.SignerCertificate.Subject)" }
+
+      - name: Install the NSIS build silently
+        shell: pwsh
+        run: |
+          $p = Start-Process -FilePath $env:NSIS_INSTALLER -ArgumentList '/S' -PassThru -Wait
+          Write-Host "NSIS setup exit code: $($p.ExitCode)"
+          if ($p.ExitCode -ne 0) { throw "NSIS setup exited $($p.ExitCode)" }
+          $exe = Join-Path $env:LOCALAPPDATA 'Programs\MemryNote\Memrynote.exe'
+          if (-not (Test-Path $exe)) { throw "missing $exe" }
+          $uninstaller = Join-Path $env:LOCALAPPDATA 'Programs\MemryNote\Uninstall MemryNote.exe'
+          if (-not (Test-Path $uninstaller)) { throw "missing $uninstaller" }
+          $entry = Get-ItemProperty $env:NSIS_UNINSTALL_KEY -ErrorAction Stop
+          Write-Host "NSIS uninstall entry: $($entry.DisplayName) $($entry.DisplayVersion)"
+          $lnk = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\MemryNote.lnk'
+          if (-not (Test-Path $lnk)) { throw "missing Start menu shortcut $lnk" }
+          "NSIS_EXE=$exe" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      # Gated off by default: the NSIS fixture is a published release, and a
+      # published NSIS build only contains the `migrate-installer` command once a
+      # release with this code has shipped. Until then the standalone step below
+      # exercises the same script the command spawns.
+      - name: Hand off through the headless CLI
+        if: env.RUN_CLI_MIGRATION == 'true'
+        shell: pwsh
+        run: |
+          $setup = Resolve-Path .\assets\MemryNote-win-Setup.exe
+          $p = Start-Process -FilePath $env:NSIS_EXE -ArgumentList '--cli', 'migrate-installer', "$setup" -PassThru -Wait -NoNewWindow
+          Write-Host "migrate-installer exit code: $($p.ExitCode)"
+          if ($p.ExitCode -ne 0) { throw "migrate-installer exited $($p.ExitCode)" }
+
+      - name: Hand off through the generated script
+        if: env.RUN_CLI_MIGRATION != 'true'
+        shell: pwsh
+        run: |
+          $app = Start-Process -FilePath $env:NSIS_EXE -PassThru
+          Start-Sleep -Seconds 5
+          $setup = Resolve-Path .\assets\MemryNote-win-Setup.exe
+          node apps/desktop/scripts/installer-handoff-script.mjs `
+            --pid $app.Id `
+            --exe Memrynote.exe `
+            --install-dir (Join-Path $env:LOCALAPPDATA 'Programs\MemryNote') `
+            --setup "$setup" `
+            --log "$PWD\velopack-setup.log" `
+            --nsis-installer $env:NSIS_INSTALLER | Out-File -FilePath handoff.cmd -Encoding ascii
+          Get-Content handoff.cmd
+          Start-Process -FilePath cmd.exe -ArgumentList '/c', "$PWD\handoff.cmd" -WindowStyle Hidden
+          Start-Sleep -Seconds 3
+          Get-Process Memrynote -ErrorAction SilentlyContinue | Stop-Process -Force
+
+      - name: Velopack install replaced the NSIS install
+        shell: pwsh
+        run: |
+          $nsisDir = Join-Path $env:LOCALAPPDATA 'Programs\MemryNote'
+          $velopackExe = Join-Path $env:LOCALAPPDATA 'MemryNote\current\Memrynote.exe'
+          $deadline = (Get-Date).AddMinutes(10)
+          while ((Get-Date) -lt $deadline -and -not (Test-Path $velopackExe)) { Start-Sleep -Seconds 5 }
+          Start-Sleep -Seconds 20
+          if (Test-Path velopack-setup.log) { Get-Content velopack-setup.log -Tail 40 }
+          if (-not (Test-Path $velopackExe)) { throw "hand-off did not produce $velopackExe" }
+          if (Test-Path $nsisDir) { Get-ChildItem $nsisDir -Recurse | Format-Table FullName; throw "NSIS install still present at $nsisDir" }
+          if (Test-Path $env:NSIS_UNINSTALL_KEY) { throw "NSIS uninstall entry still present" }
+          $sig = Get-AuthenticodeSignature $velopackExe
+          Write-Host "Memrynote.exe : $($sig.Status) / $($sig.SignerCertificate.Subject)"
+          if ($sig.Status -ne 'Valid') { throw "Memrynote.exe signature status: $($sig.Status)" }
+          $lnk = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\MemryNote.lnk'
+          if (-not (Test-Path $lnk)) { throw "missing Start menu shortcut $lnk after hand-off" }
+          $entry = Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\MemryNote' -ErrorAction Stop
+          Write-Host "Velopack uninstall entry: $($entry.DisplayName) $($entry.DisplayVersion)"
+          $running = @(Get-Process Memrynote -ErrorAction SilentlyContinue)
+          $running | Format-Table Id, Path
+          $fromVelopack = @($running | Where-Object { $_.Path -eq $velopackExe })
+          if ($fromVelopack.Count -eq 0) { throw 'Setup.exe did not leave Memrynote.exe running from the Velopack install' }
+          $running | Stop-Process -Force
+
+      - name: Collect logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: velopack-migrate-logs
+          path: |
+            handoff.cmd
+            velopack-setup.log
+            ${{ env.LOCALAPPDATA }}\MemryNote\*.log
+            ${{ env.APPDATA }}\memrynote\logs\*.log
           if-no-files-found: ignore

--- a/apps/desktop/scripts/installer-handoff-script.mjs
+++ b/apps/desktop/scripts/installer-handoff-script.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Renders the NSIS -> Velopack hand-off batch script for the smoke workflow.
+//
+//   node scripts/installer-handoff-script.mjs --pid N --exe Memrynote.exe --install-dir D \
+//     --setup S --log L [--nsis-installer P] > handoff.cmd
+//
+// Mirrors buildInstallerHandoffPlan for the derived paths; the TS module stays
+// import-free so Node can strip its types.
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { renderInstallerHandoffScript } from '../src/main/installer-handoff-script.ts'
+
+const USAGE =
+  'usage: installer-handoff-script.mjs --pid N --exe NAME --install-dir DIR --setup PATH --log PATH [--nsis-installer PATH]'
+
+function parseArgs(argv) {
+  const options = {}
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i]
+    const value = argv[i + 1]
+    if (!key.startsWith('--') || value === undefined) {
+      return null
+    }
+    options[key.slice(2)] = value
+  }
+  return options
+}
+
+const options = parseArgs(process.argv.slice(2))
+const required = ['pid', 'exe', 'install-dir', 'setup', 'log']
+if (!options || required.some((key) => !options[key])) {
+  process.stderr.write(`${USAGE}\n`)
+  process.exit(2)
+}
+
+const appPid = Number(options.pid)
+if (!Number.isInteger(appPid) || appPid <= 0) {
+  process.stderr.write(`--pid must be a positive integer, got ${options.pid}\n`)
+  process.exit(2)
+}
+
+process.stdout.write(
+  renderInstallerHandoffScript({
+    appPid,
+    appExeName: options.exe,
+    installDir: options['install-dir'],
+    uninstallerPath: path.win32.join(options['install-dir'], 'Uninstall MemryNote.exe'),
+    workDir: path.win32.join(tmpdir(), `memry-installer-handoff-${appPid}`),
+    setupExePath: options.setup,
+    setupLogPath: options.log,
+    nsisInstallerPath: options['nsis-installer'] ?? null
+  })
+)

--- a/apps/desktop/src/main/cli/headless.test.ts
+++ b/apps/desktop/src/main/cli/headless.test.ts
@@ -31,4 +31,20 @@ describe('headless CLI mode', () => {
     expect(runCli).toHaveBeenCalledWith(['--vault', '/Users/test/MemryVault', 'vault', 'status'])
     expect(exit).toHaveBeenCalledWith(2)
   })
+
+  it('routes migrate-installer to its own command instead of the vault CLI', async () => {
+    const runCli = vi.fn(async () => 0)
+    const migrateInstaller = vi.fn(async () => 1)
+    const exit = vi.fn()
+
+    await runHeadlessCli(['migrate-installer', 'C:\\Downloads\\MemryNote-win-Setup.exe'], {
+      runCli,
+      migrateInstaller,
+      exit
+    })
+
+    expect(migrateInstaller).toHaveBeenCalledWith(['C:\\Downloads\\MemryNote-win-Setup.exe'])
+    expect(runCli).not.toHaveBeenCalled()
+    expect(exit).toHaveBeenCalledWith(1)
+  })
 })

--- a/apps/desktop/src/main/cli/headless.ts
+++ b/apps/desktop/src/main/cli/headless.ts
@@ -1,5 +1,6 @@
 import { app } from 'electron'
 import { runCli as defaultRunCli } from '@memry/cli'
+import { runMigrateInstallerCommand } from './migrate-installer'
 import { createDesktopCliVaultRegistry } from './vault-registry'
 
 export function getHeadlessCliArgs(argv: string[]): string[] | null {
@@ -10,13 +11,22 @@ export function getHeadlessCliArgs(argv: string[]): string[] | null {
 
 interface HeadlessCliDeps {
   runCli?: (args: string[]) => Promise<number>
+  migrateInstaller?: (args: string[]) => Promise<number>
   exit?: (code: number) => void
 }
 
 export async function runHeadlessCli(args: string[], deps: HeadlessCliDeps = {}): Promise<void> {
   const exit = deps.exit ?? ((code: number) => app.exit(code))
-  const code = deps.runCli
-    ? await deps.runCli(args)
-    : await defaultRunCli(args, undefined, { vaultRegistry: createDesktopCliVaultRegistry() })
+  const code = await runCommand(args, deps)
   exit(code)
+}
+
+async function runCommand(args: string[], deps: HeadlessCliDeps): Promise<number> {
+  if (args[0] === 'migrate-installer') {
+    return (deps.migrateInstaller ?? runMigrateInstallerCommand)(args.slice(1))
+  }
+  if (deps.runCli) {
+    return deps.runCli(args)
+  }
+  return defaultRunCli(args, undefined, { vaultRegistry: createDesktopCliVaultRegistry() })
 }

--- a/apps/desktop/src/main/cli/migrate-installer.test.ts
+++ b/apps/desktop/src/main/cli/migrate-installer.test.ts
@@ -1,0 +1,135 @@
+import path from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => 'C:\\Users\\kaan\\AppData\\Roaming\\memrynote') }
+}))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import { runMigrateInstallerCommand, type MigrateInstallerDeps } from './migrate-installer'
+
+const EXEC_PATH = 'C:\\Users\\kaan\\AppData\\Local\\Programs\\MemryNote\\Memrynote.exe'
+const USER_DATA = 'C:\\Users\\kaan\\AppData\\Roaming\\memrynote'
+const SOURCE = 'C:\\Users\\kaan\\Downloads\\MemryNote-win-Setup.exe'
+const SETUP_COPY = path.win32.join(USER_DATA, 'installer-handoff', 'MemryNote-win-Setup.exe')
+const HANDOFF_DIR = path.win32.join(USER_DATA, 'installer-handoff')
+
+function makeDeps(overrides: Partial<MigrateInstallerDeps> = {}) {
+  const stdout: string[] = []
+  const stderr: string[] = []
+  const deps: MigrateInstallerDeps = {
+    platform: 'win32',
+    execPath: EXEC_PATH,
+    pid: 4321,
+    tmpDir: 'C:\\Temp',
+    userDataDir: USER_DATA,
+    fs: {
+      existsSync: vi.fn(
+        (p: unknown) => String(p) === SOURCE || String(p).endsWith('Uninstall MemryNote.exe')
+      ),
+      mkdirSync: vi.fn(),
+      rmSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      copyFileSync: vi.fn(),
+      createWriteStream: vi.fn()
+    } as unknown as MigrateInstallerDeps['fs'],
+    verify: vi.fn(async () => ({
+      ok: true as const,
+      subject: 'CN=Open Source Developer Kaan Karaca'
+    })),
+    spawn: vi.fn(() => true),
+    stdout: (line) => stdout.push(line),
+    stderr: (line) => stderr.push(line),
+    ...overrides
+  }
+  return { deps, stdout, stderr }
+}
+
+describe('migrate-installer command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('is Windows only', async () => {
+    const { deps, stderr } = makeDeps({ platform: 'darwin' })
+
+    await expect(runMigrateInstallerCommand([SOURCE], deps)).resolves.toBe(1)
+
+    expect(stderr).toEqual(['migrate-installer is only available on Windows.'])
+    expect(deps.spawn).not.toHaveBeenCalled()
+  })
+
+  it('prints usage without a path', async () => {
+    const { deps, stderr } = makeDeps()
+
+    await expect(runMigrateInstallerCommand([], deps)).resolves.toBe(1)
+
+    expect(stderr).toEqual(['Usage: --cli migrate-installer <path-to-MemryNote-win-Setup.exe>'])
+  })
+
+  it('prints usage when the file does not exist', async () => {
+    const { deps, stderr } = makeDeps()
+
+    await expect(runMigrateInstallerCommand(['C:\\missing\\Setup.exe'], deps)).resolves.toBe(1)
+
+    expect(stderr).toEqual(['Usage: --cli migrate-installer <path-to-MemryNote-win-Setup.exe>'])
+    expect(deps.verify).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the running app is not an NSIS install', async () => {
+    const { deps, stderr } = makeDeps()
+    vi.mocked(deps.fs.existsSync).mockImplementation((p: unknown) => String(p) === SOURCE)
+
+    await expect(runMigrateInstallerCommand([SOURCE], deps)).resolves.toBe(1)
+
+    expect(stderr).toEqual(['This is not an NSIS install of MemryNote; nothing to migrate.'])
+    expect(deps.fs.copyFileSync).not.toHaveBeenCalled()
+  })
+
+  it('verifies the copy and refuses to run an installer that does not verify', async () => {
+    const { deps, stderr } = makeDeps({
+      verify: vi.fn(async () => ({ ok: false as const, reason: 'signature status 2' }))
+    })
+
+    await expect(runMigrateInstallerCommand([SOURCE], deps)).resolves.toBe(1)
+
+    expect(deps.fs.copyFileSync).toHaveBeenCalledWith(SOURCE, SETUP_COPY)
+    expect(deps.verify).toHaveBeenCalledWith(SETUP_COPY)
+    expect(deps.fs.rmSync).toHaveBeenLastCalledWith(HANDOFF_DIR, { recursive: true, force: true })
+    expect(stderr).toEqual([`Refusing to run ${SOURCE}: signature status 2`])
+    expect(deps.spawn).not.toHaveBeenCalled()
+  })
+
+  it('fails when the hand-off script cannot be spawned', async () => {
+    const { deps, stdout } = makeDeps({ spawn: vi.fn(() => false) })
+
+    await expect(runMigrateInstallerCommand([SOURCE], deps)).resolves.toBe(1)
+
+    expect(stdout).toEqual([])
+  })
+
+  it('schedules the hand-off from a verified copy', async () => {
+    const { deps, stdout, stderr } = makeDeps()
+
+    await expect(runMigrateInstallerCommand([SOURCE], deps)).resolves.toBe(0)
+
+    expect(deps.fs.rmSync).toHaveBeenCalledWith(HANDOFF_DIR, { recursive: true, force: true })
+    expect(deps.fs.mkdirSync).toHaveBeenCalledWith(HANDOFF_DIR, { recursive: true })
+    expect(deps.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appPid: 4321,
+        appExeName: 'Memrynote.exe',
+        installDir: 'C:\\Users\\kaan\\AppData\\Local\\Programs\\MemryNote',
+        setupExePath: SETUP_COPY,
+        nsisInstallerPath: null
+      }),
+      { tmpDir: 'C:\\Temp', pid: 4321, fs: deps.fs }
+    )
+    expect(stdout).toEqual([
+      'Hand-off scheduled. MemryNote reinstalls with the new installer once this process exits.'
+    ])
+    expect(stderr).toEqual([])
+  })
+})

--- a/apps/desktop/src/main/cli/migrate-installer.ts
+++ b/apps/desktop/src/main/cli/migrate-installer.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { app } from 'electron'
+import {
+  buildInstallerHandoffPlan,
+  spawnInstallerHandoff,
+  verifyAuthenticode,
+  type InstallerHandoffDeps
+} from '../installer-handoff'
+import { detectWindowsInstallLayout } from '../windows-install-layout'
+
+const USAGE = 'Usage: --cli migrate-installer <path-to-MemryNote-win-Setup.exe>'
+
+export interface MigrateInstallerDeps {
+  platform: NodeJS.Platform
+  execPath: string
+  pid: number
+  tmpDir: string
+  userDataDir: string
+  fs: InstallerHandoffDeps['fs']
+  verify: typeof verifyAuthenticode
+  spawn: typeof spawnInstallerHandoff
+  stdout(line: string): void
+  stderr(line: string): void
+}
+
+function defaultDeps(): MigrateInstallerDeps {
+  return {
+    platform: process.platform,
+    execPath: process.execPath,
+    pid: process.pid,
+    tmpDir: tmpdir(),
+    userDataDir: app.getPath('userData'),
+    fs,
+    verify: verifyAuthenticode,
+    spawn: spawnInstallerHandoff,
+    stdout: (line) => process.stdout.write(`${line}\n`),
+    stderr: (line) => process.stderr.write(`${line}\n`)
+  }
+}
+
+export async function runMigrateInstallerCommand(
+  args: string[],
+  overrides: Partial<MigrateInstallerDeps> = {}
+): Promise<number> {
+  const deps: MigrateInstallerDeps = { ...defaultDeps(), ...overrides }
+  if (deps.platform !== 'win32') {
+    deps.stderr('migrate-installer is only available on Windows.')
+    return 1
+  }
+  const source = args[0]
+  if (!source || !deps.fs.existsSync(source)) {
+    deps.stderr(USAGE)
+    return 1
+  }
+  if (detectWindowsInstallLayout(deps.execPath, deps.fs.existsSync) !== 'nsis') {
+    deps.stderr('This is not an NSIS install of MemryNote; nothing to migrate.')
+    return 1
+  }
+
+  const plan = buildInstallerHandoffPlan({
+    pid: deps.pid,
+    execPath: deps.execPath,
+    tmpDir: deps.tmpDir,
+    userDataDir: deps.userDataDir,
+    nsisInstallerPath: null
+  })
+  const handoffDir = path.win32.dirname(plan.setupExePath)
+  deps.fs.rmSync(handoffDir, { recursive: true, force: true })
+  deps.fs.mkdirSync(handoffDir, { recursive: true })
+  deps.fs.copyFileSync(source, plan.setupExePath)
+
+  const verdict = await deps.verify(plan.setupExePath)
+  if (!verdict.ok) {
+    deps.fs.rmSync(handoffDir, { recursive: true, force: true })
+    deps.stderr(`Refusing to run ${source}: ${verdict.reason}`)
+    return 1
+  }
+
+  if (!deps.spawn(plan, { tmpDir: deps.tmpDir, pid: deps.pid, fs: deps.fs })) {
+    return 1
+  }
+  deps.stdout(
+    'Hand-off scheduled. MemryNote reinstalls with the new installer once this process exits.'
+  )
+  return 0
+}

--- a/apps/desktop/src/main/installer-handoff-script.test.ts
+++ b/apps/desktop/src/main/installer-handoff-script.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import {
+  judgeAuthenticode,
+  renderInstallerHandoffScript,
+  resolveReleaseTag,
+  velopackSetupUrl,
+  type InstallerHandoffPlan
+} from './installer-handoff-script'
+
+const plan: InstallerHandoffPlan = {
+  appPid: 1234,
+  appExeName: 'Memrynote.exe',
+  installDir: String.raw`C:\Users\kaan\AppData\Local\Programs\MemryNote`,
+  uninstallerPath: String.raw`C:\Users\kaan\AppData\Local\Programs\MemryNote\Uninstall MemryNote.exe`,
+  workDir: String.raw`C:\Users\kaan\AppData\Local\Temp\memry-installer-handoff-1234`,
+  setupExePath: String.raw`C:\Users\kaan\AppData\Roaming\memrynote\installer-handoff\MemryNote-win-Setup.exe`,
+  setupLogPath: String.raw`C:\Users\kaan\AppData\Roaming\memrynote\logs\velopack-setup.log`,
+  nsisInstallerPath: String.raw`C:\Users\kaan\AppData\Local\memrynote-updater\pending\MemryNote-2026.911.1-setup.exe`
+}
+
+const scriptLines = (nsisInstaller: string): string[] => [
+  '@echo off',
+  'setlocal',
+  'rem MemryNote installer hand-off: wait for the app to exit, remove the NSIS install, install the Velopack build.',
+  'set "APP_PID=1234"',
+  'set "APP_EXE=Memrynote.exe"',
+  String.raw`set "INSTALL_DIR=C:\Users\kaan\AppData\Local\Programs\MemryNote"`,
+  String.raw`set "UNINSTALLER=C:\Users\kaan\AppData\Local\Programs\MemryNote\Uninstall MemryNote.exe"`,
+  String.raw`set "WORK_DIR=C:\Users\kaan\AppData\Local\Temp\memry-installer-handoff-1234"`,
+  String.raw`set "SETUP=C:\Users\kaan\AppData\Roaming\memrynote\installer-handoff\MemryNote-win-Setup.exe"`,
+  String.raw`set "SETUP_LOG=C:\Users\kaan\AppData\Roaming\memrynote\logs\velopack-setup.log"`,
+  `set "NSIS_INSTALLER=${nsisInstaller}"`,
+  String.raw`set "VELOPACK_EXE=%LocalAppData%\MemryNote\current\Memrynote.exe"`,
+  '',
+  ':wait_for_exit',
+  'tasklist /FI "PID eq %APP_PID%" /FI "IMAGENAME eq %APP_EXE%" /NH 2>nul | find /I "%APP_EXE%" >nul',
+  'if not errorlevel 1 (',
+  '  ping -n 2 127.0.0.1 >nul',
+  '  goto wait_for_exit',
+  ')',
+  '',
+  'if not exist "%WORK_DIR%" mkdir "%WORK_DIR%"',
+  String.raw`copy /y "%UNINSTALLER%" "%WORK_DIR%\Uninstall MemryNote.exe" >nul`,
+  String.raw`start "" /wait "%WORK_DIR%\Uninstall MemryNote.exe" /S _?=%INSTALL_DIR%`,
+  '',
+  'start "" /wait "%SETUP%" --silent --verbose --log "%SETUP_LOG%"',
+  '',
+  'if not exist "%VELOPACK_EXE%" (',
+  '  if exist "%NSIS_INSTALLER%" start "" /wait "%NSIS_INSTALLER%" /S --force-run',
+  ')',
+  '',
+  'del /q "%SETUP%" >nul 2>&1',
+  'rmdir /s /q "%WORK_DIR%" >nul 2>&1',
+  '(goto) 2>nul & del "%~f0"'
+]
+
+describe('renderInstallerHandoffScript', () => {
+  it('renders the pinned batch script with CRLF line endings', () => {
+    const script = renderInstallerHandoffScript(plan)
+
+    expect(script).toBe(
+      `${scriptLines(String.raw`C:\Users\kaan\AppData\Local\memrynote-updater\pending\MemryNote-2026.911.1-setup.exe`).join('\r\n')}\r\n`
+    )
+    expect(script.split('\r\n').join('')).not.toContain('\n')
+  })
+
+  it('leaves the NSIS fallback empty when no NSIS installer is on disk', () => {
+    const script = renderInstallerHandoffScript({ ...plan, nsisInstallerPath: null })
+
+    expect(script).toBe(`${scriptLines('').join('\r\n')}\r\n`)
+    expect(script).toContain('set "NSIS_INSTALLER="\r\n')
+  })
+})
+
+describe('resolveReleaseTag', () => {
+  it('prefers the GitHub tag on the update info', () => {
+    expect(
+      resolveReleaseTag({
+        tag: 'v2026-09-11.1',
+        files: [{ url: 'https://github.com/memrynote/memry/releases/download/v0/x.exe' }]
+      })
+    ).toBe('v2026-09-11.1')
+  })
+
+  it('falls back to an absolute release-asset url', () => {
+    expect(
+      resolveReleaseTag({
+        files: [
+          { url: 'MemryNote-2026.911.1-setup.exe' },
+          {
+            url: 'https://github.com/memrynote/memry/releases/download/v2026-09-11.1/MemryNote-2026.911.1-setup.exe'
+          }
+        ]
+      })
+    ).toBe('v2026-09-11.1')
+  })
+
+  it('returns null when neither a tag nor an absolute url is present', () => {
+    expect(resolveReleaseTag({ files: [{ url: 'MemryNote-2026.911.1-setup.exe' }] })).toBeNull()
+    expect(resolveReleaseTag({ tag: '' })).toBeNull()
+    expect(resolveReleaseTag({})).toBeNull()
+  })
+})
+
+describe('velopackSetupUrl', () => {
+  it('points at the Velopack Setup.exe of the release tag', () => {
+    expect(velopackSetupUrl('v2026-09-11.1')).toBe(
+      'https://github.com/memrynote/memry/releases/download/v2026-09-11.1/MemryNote-win-Setup.exe'
+    )
+  })
+})
+
+describe('judgeAuthenticode', () => {
+  const subject = 'CN=Open Source Developer Kaan Karaca, O=Open Source Developer, C=TR'
+  const expectedSubject = 'CN=Open Source Developer Kaan Karaca'
+
+  it('accepts a Valid signature (Status 0) from the expected signer', () => {
+    const stdout = JSON.stringify({
+      Status: 0,
+      StatusMessage: 'Signature verified.',
+      SignerCertificate: { Subject: subject }
+    })
+    expect(judgeAuthenticode(stdout, expectedSubject)).toEqual({ ok: true, subject })
+  })
+
+  it('accepts a Valid signature rendered as the enum name', () => {
+    const stdout = JSON.stringify({ Status: 'Valid', SignerCertificate: { Subject: subject } })
+    expect(judgeAuthenticode(stdout, expectedSubject)).toEqual({ ok: true, subject })
+  })
+
+  it('rejects a Valid signature from another signer', () => {
+    const stdout = JSON.stringify({
+      Status: 0,
+      SignerCertificate: { Subject: 'CN=Someone Else, O=Elsewhere' }
+    })
+    expect(judgeAuthenticode(stdout, expectedSubject)).toEqual({
+      ok: false,
+      reason: 'unexpected signer CN=Someone Else, O=Elsewhere'
+    })
+  })
+
+  it('rejects an unsigned file (Status 2)', () => {
+    const stdout = JSON.stringify({
+      Status: 2,
+      StatusMessage: 'The file is not digitally signed.',
+      SignerCertificate: null
+    })
+    expect(judgeAuthenticode(stdout, expectedSubject)).toEqual({
+      ok: false,
+      reason: 'signature status 2 (The file is not digitally signed.)'
+    })
+  })
+
+  it('rejects output that is not JSON', () => {
+    expect(judgeAuthenticode('Get-AuthenticodeSignature : not found', expectedSubject)).toEqual({
+      ok: false,
+      reason: 'signature output is not JSON'
+    })
+  })
+})

--- a/apps/desktop/src/main/installer-handoff-script.ts
+++ b/apps/desktop/src/main/installer-handoff-script.ts
@@ -1,0 +1,129 @@
+// Pure. No imports: Node strips the types of this file at runtime for
+// scripts/installer-handoff-script.mjs, so it must stay free of runtime
+// dependencies and of non-erasable syntax (enum, namespace, parameter properties).
+
+export const VELOPACK_SETUP_ASSET_NAME = 'MemryNote-win-Setup.exe'
+export const INSTALLER_HANDOFF_SIGNER_SUBJECT = 'CN=Open Source Developer Kaan Karaca'
+export const GITHUB_RELEASE_DOWNLOAD_BASE = 'https://github.com/memrynote/memry/releases/download'
+
+/** Everything the detached script needs. Absolute Windows paths, already resolved by the caller. */
+export interface InstallerHandoffPlan {
+  appPid: number
+  /** 'Memrynote.exe' */
+  appExeName: string
+  /** dirname(process.execPath), which is the NSIS $INSTDIR. */
+  installDir: string
+  /** installDir\Uninstall MemryNote.exe */
+  uninstallerPath: string
+  /** <tmp>\memry-installer-handoff-<pid>; the uninstaller copy lives here. */
+  workDir: string
+  /** <userData>\installer-handoff\MemryNote-win-Setup.exe */
+  setupExePath: string
+  /** <userData>\logs\velopack-setup.log */
+  setupLogPath: string
+  /**
+   * electron-updater's already-downloaded NSIS setup.exe; the safety net if
+   * Setup.exe leaves no app behind. null from the CLI.
+   */
+  nsisInstallerPath: string | null
+}
+
+export type AuthenticodeVerdict = { ok: true; subject: string } | { ok: false; reason: string }
+
+/**
+ * `ping -n 2 127.0.0.1` is the sleep: `timeout /t` aborts with "Input redirection
+ * is not supported" when stdin is not a console, which it is not under
+ * `stdio: 'ignore'`. `tasklist` is filtered by PID and image name so a recycled
+ * PID cannot match. The uninstaller runs from a copy with `_?=` (last argument,
+ * unquoted) so it blocks and `RMDir /r $INSTDIR` can remove the original; no
+ * `--updated`, so the tolerant removal path runs. Uninstall before Setup: the
+ * NSIS uninstaller deletes the Start-menu and desktop `MemryNote.lnk`, the same
+ * paths Velopack creates. Setup.exe launches the app itself.
+ */
+export function renderInstallerHandoffScript(plan: InstallerHandoffPlan): string {
+  const lines = [
+    '@echo off',
+    'setlocal',
+    'rem MemryNote installer hand-off: wait for the app to exit, remove the NSIS install, install the Velopack build.',
+    `set "APP_PID=${plan.appPid}"`,
+    `set "APP_EXE=${plan.appExeName}"`,
+    `set "INSTALL_DIR=${plan.installDir}"`,
+    `set "UNINSTALLER=${plan.uninstallerPath}"`,
+    `set "WORK_DIR=${plan.workDir}"`,
+    `set "SETUP=${plan.setupExePath}"`,
+    `set "SETUP_LOG=${plan.setupLogPath}"`,
+    `set "NSIS_INSTALLER=${plan.nsisInstallerPath ?? ''}"`,
+    'set "VELOPACK_EXE=%LocalAppData%\\MemryNote\\current\\Memrynote.exe"',
+    '',
+    ':wait_for_exit',
+    'tasklist /FI "PID eq %APP_PID%" /FI "IMAGENAME eq %APP_EXE%" /NH 2>nul | find /I "%APP_EXE%" >nul',
+    'if not errorlevel 1 (',
+    '  ping -n 2 127.0.0.1 >nul',
+    '  goto wait_for_exit',
+    ')',
+    '',
+    'if not exist "%WORK_DIR%" mkdir "%WORK_DIR%"',
+    'copy /y "%UNINSTALLER%" "%WORK_DIR%\\Uninstall MemryNote.exe" >nul',
+    'start "" /wait "%WORK_DIR%\\Uninstall MemryNote.exe" /S _?=%INSTALL_DIR%',
+    '',
+    'start "" /wait "%SETUP%" --silent --verbose --log "%SETUP_LOG%"',
+    '',
+    'if not exist "%VELOPACK_EXE%" (',
+    '  if exist "%NSIS_INSTALLER%" start "" /wait "%NSIS_INSTALLER%" /S --force-run',
+    ')',
+    '',
+    'del /q "%SETUP%" >nul 2>&1',
+    'rmdir /s /q "%WORK_DIR%" >nul 2>&1',
+    '(goto) 2>nul & del "%~f0"'
+  ]
+  return `${lines.join('\r\n')}\r\n`
+}
+
+/** GitHub's `update-downloaded` payload carries `tag`; `files[].url` is the fallback when it is absolute. */
+export function resolveReleaseTag(info: {
+  tag?: unknown
+  files?: ReadonlyArray<{ url?: unknown }>
+}): string | null {
+  if (typeof info.tag === 'string' && info.tag) return info.tag
+  for (const file of info.files ?? []) {
+    if (typeof file.url !== 'string') continue
+    const match = /\/releases\/download\/([^/]+)\//.exec(file.url)
+    if (match) return match[1]
+  }
+  return null
+}
+
+export function velopackSetupUrl(tag: string): string {
+  return `${GITHUB_RELEASE_DOWNLOAD_BASE}/${encodeURIComponent(tag)}/${VELOPACK_SETUP_ASSET_NAME}`
+}
+
+/** Parses `Get-AuthenticodeSignature | ConvertTo-Json -Compress` output. Valid == Status 0 or 'Valid'. */
+export function judgeAuthenticode(stdout: string, expectedSubject: string): AuthenticodeVerdict {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stdout)
+  } catch {
+    return { ok: false, reason: 'signature output is not JSON' }
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return { ok: false, reason: 'signature output is not an object' }
+  }
+  const { Status, StatusMessage, SignerCertificate } = parsed as {
+    Status?: unknown
+    StatusMessage?: unknown
+    SignerCertificate?: { Subject?: unknown } | null
+  }
+  if (Status !== 0 && Status !== 'Valid') {
+    const status = typeof Status === 'string' || typeof Status === 'number' ? Status : 'unknown'
+    const message = typeof StatusMessage === 'string' && StatusMessage ? ` (${StatusMessage})` : ''
+    return { ok: false, reason: `signature status ${status}${message}` }
+  }
+  const subject = SignerCertificate?.Subject
+  if (typeof subject !== 'string' || !subject.includes(expectedSubject)) {
+    return {
+      ok: false,
+      reason: `unexpected signer ${typeof subject === 'string' ? subject : 'none'}`
+    }
+  }
+  return { ok: true, subject }
+}

--- a/apps/desktop/src/main/installer-handoff.test.ts
+++ b/apps/desktop/src/main/installer-handoff.test.ts
@@ -1,0 +1,386 @@
+import path from 'node:path'
+import { Readable, Writable } from 'node:stream'
+import type { UpdateDownloadedEvent } from 'electron-updater'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => String.raw`C:\Users\kaan\AppData\Roaming\memrynote`) }
+}))
+vi.mock('./lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import {
+  buildInstallerHandoffPlan,
+  createInstallerHandoff,
+  verifyAuthenticode,
+  type InstallerHandoffDeps
+} from './installer-handoff'
+import { renderInstallerHandoffScript } from './installer-handoff-script'
+import type { UpdaterHost } from './updater-backend'
+
+const USER_DATA = String.raw`C:\Users\kaan\AppData\Roaming\memrynote`
+const TMP = String.raw`C:\Users\kaan\AppData\Local\Temp`
+const EXEC_PATH = String.raw`C:\Users\kaan\AppData\Local\Programs\MemryNote\Memrynote.exe`
+const HANDOFF_DIR = path.win32.join(USER_DATA, 'installer-handoff')
+const SETUP_URL =
+  'https://github.com/memrynote/memry/releases/download/v2026-09-11.1/MemryNote-win-Setup.exe'
+const NSIS_INSTALLER = String.raw`C:\Users\kaan\AppData\Local\memrynote-updater\pending\MemryNote-2026.911.1-setup.exe`
+const VALID_SIGNATURE = JSON.stringify({
+  Status: 0,
+  SignerCertificate: { Subject: 'CN=Open Source Developer Kaan Karaca, C=TR' }
+})
+
+type DownloadedInfo = UpdateDownloadedEvent & { tag?: string }
+
+function makeInfo(overrides: Partial<DownloadedInfo> = {}): DownloadedInfo {
+  return {
+    version: '2026.911.1',
+    tag: 'v2026-09-11.1',
+    files: [{ url: 'MemryNote-2026.911.1-setup.exe', sha512: 'sha' }],
+    path: 'MemryNote-2026.911.1-setup.exe',
+    sha512: 'sha',
+    releaseDate: '2026-09-11',
+    downloadedFile: NSIS_INSTALLER,
+    ...overrides
+  }
+}
+
+function makeHost(): UpdaterHost {
+  return {
+    onChecking: vi.fn(),
+    onUpdateAvailable: vi.fn(() => true),
+    onUpToDate: vi.fn(),
+    onDownloadProgress: vi.fn(),
+    onDownloaded: vi.fn(),
+    onError: vi.fn(),
+    currentPhase: vi.fn(() => 'download' as const),
+    isAutoDownloadEnabled: vi.fn(() => true)
+  }
+}
+
+function response(status: number, body?: Readable, contentLength?: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(
+      contentLength === undefined ? {} : { 'content-length': `${contentLength}` }
+    ),
+    body
+  } as unknown as Response
+}
+
+interface Harness {
+  deps: InstallerHandoffDeps
+  host: UpdaterHost
+  written: Buffer[]
+  fetch: ReturnType<typeof vi.fn>
+  spawn: ReturnType<typeof vi.fn>
+  child: { unref: ReturnType<typeof vi.fn>; on: ReturnType<typeof vi.fn> }
+  execFile: ReturnType<typeof vi.fn>
+}
+
+function makeHarness(
+  options: { head?: Response; get?: () => Response; signature?: string } = {}
+): Harness {
+  const written: Buffer[] = []
+  const child = { unref: vi.fn(), on: vi.fn() }
+  const head = options.head ?? response(200)
+  const get =
+    options.get ??
+    (() => response(200, Readable.from([Buffer.from('abcd'), Buffer.from('efghij')]), 10))
+  const fetch = vi.fn(async (_url: string, init?: RequestInit) =>
+    init?.method === 'HEAD' ? head : get()
+  )
+  const spawn = vi.fn(() => child)
+  const execFile = vi.fn(
+    (
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout: string, stderr: string) => void
+    ) => {
+      callback(null, options.signature ?? VALID_SIGNATURE, '')
+    }
+  )
+  const deps: InstallerHandoffDeps = {
+    userDataDir: USER_DATA,
+    tmpDir: TMP,
+    execPath: EXEC_PATH,
+    pid: 1234,
+    fetch: fetch as unknown as typeof globalThis.fetch,
+    execFile: execFile as unknown as InstallerHandoffDeps['execFile'],
+    spawn: spawn as unknown as InstallerHandoffDeps['spawn'],
+    fs: {
+      existsSync: vi.fn((p: unknown) => String(p).endsWith('Uninstall MemryNote.exe')),
+      mkdirSync: vi.fn(),
+      rmSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      copyFileSync: vi.fn(),
+      createWriteStream: vi.fn(
+        () =>
+          new Writable({
+            write(chunk: Buffer, _encoding, callback) {
+              written.push(chunk)
+              callback()
+            }
+          })
+      ) as unknown as InstallerHandoffDeps['fs']['createWriteStream']
+    }
+  }
+  return { deps, host: makeHost(), written, fetch, spawn, child, execFile }
+}
+
+const expectedPlan = (nsisInstallerPath: string | null = NSIS_INSTALLER) =>
+  buildInstallerHandoffPlan({
+    pid: 1234,
+    execPath: EXEC_PATH,
+    tmpDir: TMP,
+    userDataDir: USER_DATA,
+    nsisInstallerPath
+  })
+
+describe('createInstallerHandoff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('removes a stale hand-off directory at startup', () => {
+    const { deps, host } = makeHarness()
+
+    createInstallerHandoff(host, deps)
+
+    expect(deps.fs.rmSync).toHaveBeenCalledWith(HANDOFF_DIR, { recursive: true, force: true })
+  })
+
+  it('declines without an error when the release carries no Velopack installer', async () => {
+    const harness = makeHarness({ head: response(404) })
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo(), vi.fn())
+
+    expect(harness.fetch).toHaveBeenCalledTimes(1)
+    expect(harness.fetch).toHaveBeenCalledWith(SETUP_URL, { method: 'HEAD' })
+    expect(harness.host.onError).not.toHaveBeenCalled()
+    expect(handoff.armed()).toBe(false)
+    expect(handoff.launch()).toBe(false)
+  })
+
+  it('reports a failed HEAD through the host and declines', async () => {
+    const harness = makeHarness({ head: response(500) })
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo(), vi.fn())
+
+    expect(harness.host.onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'INSTALLER_HANDOFF_DOWNLOAD_FAILED' })
+    )
+    expect(harness.deps.fs.createWriteStream).not.toHaveBeenCalled()
+    expect(handoff.armed()).toBe(false)
+  })
+
+  it('reports a network failure through the host and declines', async () => {
+    const harness = makeHarness()
+    harness.fetch.mockRejectedValue(new Error('ENOTFOUND github.com'))
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo(), vi.fn())
+
+    expect(harness.host.onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'INSTALLER_HANDOFF_DOWNLOAD_FAILED',
+        message: expect.stringContaining('ENOTFOUND')
+      })
+    )
+    expect(handoff.armed()).toBe(false)
+  })
+
+  it('streams the installer to disk and reports progress from 0 to 100', async () => {
+    const harness = makeHarness()
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+    const onProgress = vi.fn()
+
+    await handoff.prepare(makeInfo(), onProgress)
+
+    expect(harness.fetch).toHaveBeenNthCalledWith(2, SETUP_URL)
+    expect(harness.deps.fs.mkdirSync).toHaveBeenCalledWith(HANDOFF_DIR, { recursive: true })
+    expect(harness.deps.fs.createWriteStream).toHaveBeenCalledWith(expectedPlan().setupExePath)
+    expect(Buffer.concat(harness.written).toString()).toBe('abcdefghij')
+    const percents = onProgress.mock.calls.map(([percent]) => percent as number)
+    expect(percents[0]).toBe(0)
+    expect(percents).toContain(40)
+    expect(percents.at(-1)).toBe(100)
+    expect(percents).toEqual([...percents].sort((a, b) => a - b))
+  })
+
+  it('reports a failed download through the host and removes the partial file', async () => {
+    const harness = makeHarness({
+      get: () =>
+        response(
+          200,
+          new Readable({
+            read() {
+              this.destroy(new Error('connection reset'))
+            }
+          }),
+          10
+        )
+    })
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo(), vi.fn())
+
+    expect(harness.host.onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'INSTALLER_HANDOFF_DOWNLOAD_FAILED' })
+    )
+    expect(harness.deps.fs.rmSync).toHaveBeenLastCalledWith(HANDOFF_DIR, {
+      recursive: true,
+      force: true
+    })
+    expect(handoff.armed()).toBe(false)
+  })
+
+  it('never arms an installer whose signature does not verify', async () => {
+    const harness = makeHarness({
+      signature: JSON.stringify({ Status: 2, StatusMessage: 'The file is not digitally signed.' })
+    })
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo(), vi.fn())
+
+    expect(harness.execFile).toHaveBeenCalledWith(
+      'powershell.exe',
+      expect.arrayContaining(['-Command', expect.stringContaining(expectedPlan().setupExePath)]),
+      expect.objectContaining({ windowsHide: true }),
+      expect.any(Function)
+    )
+    expect(harness.host.onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'INSTALLER_HANDOFF_UNVERIFIED',
+        message: 'signature status 2 (The file is not digitally signed.)'
+      })
+    )
+    expect(harness.deps.fs.rmSync).toHaveBeenLastCalledWith(HANDOFF_DIR, {
+      recursive: true,
+      force: true
+    })
+    expect(handoff.armed()).toBe(false)
+    expect(handoff.launch()).toBe(false)
+    expect(harness.spawn).not.toHaveBeenCalled()
+  })
+
+  it('arms after a verified download and launches the detached script', async () => {
+    const harness = makeHarness()
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo(), vi.fn())
+    expect(handoff.armed()).toBe(true)
+
+    expect(handoff.launch()).toBe(true)
+
+    const scriptPath = path.win32.join(TMP, 'memry-installer-handoff-1234.cmd')
+    expect(harness.deps.fs.writeFileSync).toHaveBeenCalledWith(
+      scriptPath,
+      renderInstallerHandoffScript(expectedPlan())
+    )
+    expect(harness.spawn).toHaveBeenCalledWith('cmd.exe', ['/c', scriptPath], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true
+    })
+    expect(harness.child.unref).toHaveBeenCalledTimes(1)
+  })
+
+  it('launches once so a second quit path cannot uninstall and install twice', async () => {
+    const harness = makeHarness()
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo(), vi.fn())
+
+    expect(handoff.launch()).toBe(true)
+    expect(handoff.launch()).toBe(false)
+    expect(harness.spawn).toHaveBeenCalledTimes(1)
+    // Still the hand-off's install, so a second marker write keeps naming it.
+    expect(handoff.armed()).toBe(true)
+  })
+
+  it('returns false from launch when the spawn throws', async () => {
+    const harness = makeHarness()
+    harness.spawn.mockImplementation(() => {
+      throw new Error('spawn cmd.exe EPERM')
+    })
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo(), vi.fn())
+
+    expect(handoff.launch()).toBe(false)
+  })
+
+  it('does not download again when the same version is reported twice', async () => {
+    const harness = makeHarness()
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo(), vi.fn())
+    const fetches = harness.fetch.mock.calls.length
+    await handoff.prepare(makeInfo(), vi.fn())
+
+    expect(harness.fetch).toHaveBeenCalledTimes(fetches)
+    expect(handoff.armed()).toBe(true)
+  })
+
+  it('shares one in-flight preparation between concurrent calls for the same version', async () => {
+    const harness = makeHarness()
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await Promise.all([handoff.prepare(makeInfo(), vi.fn()), handoff.prepare(makeInfo(), vi.fn())])
+
+    expect(harness.fetch).toHaveBeenCalledTimes(2)
+    expect(handoff.armed()).toBe(true)
+  })
+
+  it('declines before any network access when this is not an NSIS install', async () => {
+    const harness = makeHarness()
+    vi.mocked(harness.deps.fs.existsSync).mockReturnValue(false)
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo(), vi.fn())
+
+    expect(harness.fetch).not.toHaveBeenCalled()
+    expect(harness.host.onError).not.toHaveBeenCalled()
+    expect(handoff.armed()).toBe(false)
+  })
+
+  it('declines before any network access when the release tag is unknown', async () => {
+    const harness = makeHarness()
+    const handoff = createInstallerHandoff(harness.host, harness.deps)
+
+    await handoff.prepare(makeInfo({ tag: undefined }), vi.fn())
+
+    expect(harness.fetch).not.toHaveBeenCalled()
+    expect(handoff.armed()).toBe(false)
+  })
+})
+
+describe('verifyAuthenticode', () => {
+  it('turns a powershell failure into a verdict instead of a rejection', async () => {
+    const execFile = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        callback(new Error('spawn powershell.exe ENOENT'), '', '')
+      }
+    )
+
+    await expect(
+      verifyAuthenticode(String.raw`C:\x\Setup.exe`, {
+        execFile: execFile as unknown as InstallerHandoffDeps['execFile']
+      })
+    ).resolves.toEqual({
+      ok: false,
+      reason: 'Get-AuthenticodeSignature failed: spawn powershell.exe ENOENT'
+    })
+  })
+})

--- a/apps/desktop/src/main/installer-handoff.ts
+++ b/apps/desktop/src/main/installer-handoff.ts
@@ -1,0 +1,310 @@
+import { execFile as nodeExecFile, spawn as nodeSpawn } from 'node:child_process'
+import fs from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pipeline } from 'node:stream/promises'
+import { app } from 'electron'
+import type { UpdateDownloadedEvent } from 'electron-updater'
+import { createLogger } from './lib/logger'
+import {
+  INSTALLER_HANDOFF_SIGNER_SUBJECT,
+  VELOPACK_SETUP_ASSET_NAME,
+  judgeAuthenticode,
+  renderInstallerHandoffScript,
+  resolveReleaseTag,
+  velopackSetupUrl,
+  type AuthenticodeVerdict,
+  type InstallerHandoffPlan
+} from './installer-handoff-script'
+import type { UpdaterHost } from './updater-backend'
+import { NSIS_UNINSTALLER_FILENAME, detectWindowsInstallLayout } from './windows-install-layout'
+
+const logger = createLogger('InstallerHandoff')
+
+export const INSTALLER_HANDOFF_DIRNAME = 'installer-handoff'
+
+const AUTHENTICODE_TIMEOUT_MS = 60_000
+
+export type InstallerHandoffState =
+  | { status: 'idle' }
+  | { status: 'preparing'; version: string }
+  | { status: 'armed'; version: string; plan: InstallerHandoffPlan }
+  | { status: 'launched'; version: string }
+  | { status: 'declined'; version: string; reason: string }
+
+export interface InstallerHandoff {
+  /** After electron-updater downloaded the NSIS installer. Never rejects. Arms or declines. Re-entrant per version. */
+  prepare(info: UpdateDownloadedEvent, onProgress: (percent: number) => void): Promise<void>
+  /** True once a verified hand-off owns this install, and still true after launch() ran. */
+  armed(): boolean
+  /**
+   * Write the script, spawn it detached. Runs at most once per armed plan. false when
+   * not armed, already launched, or the spawn failed (caller then falls back to NSIS).
+   */
+  launch(): boolean
+}
+
+export interface InstallerHandoffDeps {
+  userDataDir: string
+  tmpDir: string
+  execPath: string
+  pid: number
+  fetch: typeof fetch
+  execFile: typeof nodeExecFile
+  spawn: typeof nodeSpawn
+  fs: Pick<
+    typeof fs,
+    'existsSync' | 'mkdirSync' | 'rmSync' | 'writeFileSync' | 'createWriteStream' | 'copyFileSync'
+  >
+}
+
+type SpawnDeps = Pick<InstallerHandoffDeps, 'spawn' | 'tmpDir' | 'pid' | 'fs'>
+
+function defaultDeps(): InstallerHandoffDeps {
+  return {
+    userDataDir: app.getPath('userData'),
+    tmpDir: tmpdir(),
+    execPath: process.execPath,
+    pid: process.pid,
+    fetch: (input, init) => fetch(input, init),
+    execFile: nodeExecFile,
+    spawn: nodeSpawn,
+    fs
+  }
+}
+
+const coded = (code: string, message: string): Error => Object.assign(new Error(message), { code })
+
+const messageOf = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+export function buildInstallerHandoffPlan(input: {
+  pid: number
+  execPath: string
+  tmpDir: string
+  userDataDir: string
+  nsisInstallerPath: string | null
+}): InstallerHandoffPlan {
+  const installDir = path.win32.dirname(input.execPath)
+  return {
+    appPid: input.pid,
+    appExeName: path.win32.basename(input.execPath),
+    installDir,
+    uninstallerPath: path.win32.join(installDir, NSIS_UNINSTALLER_FILENAME),
+    workDir: path.win32.join(input.tmpDir, `memry-installer-handoff-${input.pid}`),
+    setupExePath: path.win32.join(
+      input.userDataDir,
+      INSTALLER_HANDOFF_DIRNAME,
+      VELOPACK_SETUP_ASSET_NAME
+    ),
+    setupLogPath: path.win32.join(input.userDataDir, 'logs', 'velopack-setup.log'),
+    nsisInstallerPath: input.nsisInstallerPath
+  }
+}
+
+/** Shared with the CLI. Runs powershell; resolves to a verdict, never rejects. */
+export function verifyAuthenticode(
+  filePath: string,
+  deps: Pick<InstallerHandoffDeps, 'execFile'> = { execFile: nodeExecFile }
+): Promise<AuthenticodeVerdict> {
+  const literal = `'${filePath.replace(/'/g, "''")}'`
+  const command = `Get-AuthenticodeSignature -LiteralPath ${literal} | ConvertTo-Json -Compress`
+  return new Promise((resolve) => {
+    deps.execFile(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', command],
+      { windowsHide: true, timeout: AUTHENTICODE_TIMEOUT_MS },
+      (error, stdout) => {
+        if (error) {
+          resolve({ ok: false, reason: `Get-AuthenticodeSignature failed: ${error.message}` })
+          return
+        }
+        resolve(judgeAuthenticode(String(stdout), INSTALLER_HANDOFF_SIGNER_SUBJECT))
+      }
+    )
+  })
+}
+
+/**
+ * Shared with the CLI. Writes the script to `<tmpDir>\memry-installer-handoff-<pid>.cmd`
+ * and spawns it through cmd.exe detached, the way electron-updater spawns its own installer.
+ */
+export function spawnInstallerHandoff(
+  plan: InstallerHandoffPlan,
+  deps: Partial<SpawnDeps> = {}
+): boolean {
+  const {
+    spawn,
+    tmpDir,
+    pid,
+    fs: fsDeps
+  }: SpawnDeps = {
+    spawn: nodeSpawn,
+    tmpDir: tmpdir(),
+    pid: process.pid,
+    fs,
+    ...deps
+  }
+  const scriptPath = path.win32.join(tmpDir, `memry-installer-handoff-${pid}.cmd`)
+  try {
+    fsDeps.writeFileSync(scriptPath, renderInstallerHandoffScript(plan))
+    const child = spawn('cmd.exe', ['/c', scriptPath], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true
+    })
+    child.on('error', (error) => {
+      logger.error('installer hand-off script failed to start', error)
+    })
+    child.unref()
+    logger.info('installer hand-off launched', { scriptPath, setupExePath: plan.setupExePath })
+    return true
+  } catch (error) {
+    logger.error('installer hand-off launch failed', error)
+    return false
+  }
+}
+
+export function createInstallerHandoff(
+  host: UpdaterHost,
+  overrides: Partial<InstallerHandoffDeps> = {}
+): InstallerHandoff {
+  const deps: InstallerHandoffDeps = { ...defaultDeps(), ...overrides }
+  const handoffDir = path.win32.join(deps.userDataDir, INSTALLER_HANDOFF_DIRNAME)
+
+  const removeHandoffDir = (): void => {
+    try {
+      deps.fs.rmSync(handoffDir, { recursive: true, force: true })
+    } catch (error) {
+      logger.warn('could not remove the installer hand-off directory', { handoffDir, error })
+    }
+  }
+
+  // A crash mid-hand-off must not leave the previous Setup.exe behind.
+  removeHandoffDir()
+
+  let state: InstallerHandoffState = { status: 'idle' }
+  let inFlight: Promise<void> | null = null
+
+  async function download(
+    url: string,
+    target: string,
+    onProgress: (percent: number) => void
+  ): Promise<void> {
+    const res = await deps.fetch(url)
+    if (!res.ok || !res.body) {
+      throw new Error(`GET ${url} returned ${res.status}`)
+    }
+    const body = res.body
+    const total = Number(res.headers.get('content-length')) || 0
+    let received = 0
+    onProgress(0)
+    await pipeline(async function* () {
+      for await (const chunk of body) {
+        received += chunk.length
+        if (total > 0) onProgress(Math.min(100, (received / total) * 100))
+        yield chunk
+      }
+    }, deps.fs.createWriteStream(target))
+    onProgress(100)
+  }
+
+  async function run(
+    info: UpdateDownloadedEvent,
+    onProgress: (percent: number) => void
+  ): Promise<InstallerHandoffState> {
+    const version = info.version
+    const decline = (reason: string): InstallerHandoffState => {
+      logger.info('installer hand-off declined', { version, reason })
+      return { status: 'declined', version, reason }
+    }
+
+    const tag = resolveReleaseTag(info)
+    if (!tag) return decline('release tag unknown')
+    const layout = detectWindowsInstallLayout(deps.execPath, deps.fs.existsSync)
+    if (layout !== 'nsis') return decline(`install layout is ${layout}, not nsis`)
+
+    const url = velopackSetupUrl(tag)
+    let head: Response
+    try {
+      head = await deps.fetch(url, { method: 'HEAD' })
+    } catch (error) {
+      host.onError(
+        coded('INSTALLER_HANDOFF_DOWNLOAD_FAILED', `HEAD ${url} failed: ${messageOf(error)}`)
+      )
+      return decline('network error')
+    }
+    if (head.status === 404) return decline(`release ${tag} carries no Velopack installer`)
+    if (!head.ok) {
+      host.onError(
+        coded('INSTALLER_HANDOFF_DOWNLOAD_FAILED', `HEAD ${url} returned ${head.status}`)
+      )
+      return decline(`HEAD returned ${head.status}`)
+    }
+
+    const plan = buildInstallerHandoffPlan({
+      pid: deps.pid,
+      execPath: deps.execPath,
+      tmpDir: deps.tmpDir,
+      userDataDir: deps.userDataDir,
+      nsisInstallerPath: info.downloadedFile ?? null
+    })
+    removeHandoffDir()
+    try {
+      deps.fs.mkdirSync(handoffDir, { recursive: true })
+      await download(url, plan.setupExePath, onProgress)
+    } catch (error) {
+      removeHandoffDir()
+      host.onError(
+        coded('INSTALLER_HANDOFF_DOWNLOAD_FAILED', `download of ${url} failed: ${messageOf(error)}`)
+      )
+      return decline('download failed')
+    }
+
+    const verdict = await verifyAuthenticode(plan.setupExePath, deps)
+    if (!verdict.ok) {
+      removeHandoffDir()
+      host.onError(coded('INSTALLER_HANDOFF_UNVERIFIED', verdict.reason))
+      return decline('signature not verified')
+    }
+
+    logger.info('installer hand-off armed', { version, tag, signer: verdict.subject })
+    return { status: 'armed', version, plan }
+  }
+
+  return {
+    prepare(info, onProgress) {
+      const version = info.version
+      if (state.status === 'preparing' && state.version === version && inFlight) {
+        return inFlight
+      }
+      if (state.status !== 'idle' && state.status !== 'preparing' && state.version === version) {
+        return Promise.resolve()
+      }
+      state = { status: 'preparing', version }
+      inFlight = run(info, onProgress)
+        .then((next) => {
+          state = next
+        })
+        .catch((error: unknown) => {
+          logger.error('installer hand-off preparation failed', error)
+          state = { status: 'declined', version, reason: messageOf(error) }
+        })
+        .finally(() => {
+          inFlight = null
+        })
+      return inFlight
+    },
+    armed() {
+      return state.status === 'armed' || state.status === 'launched'
+    },
+    launch() {
+      if (state.status !== 'armed') return false
+      const { version, plan } = state
+      // The shutdown backstop can race the shutdown sequence and reach
+      // performQuitAndInstall() twice; a second uninstall + install must not run.
+      state = { status: 'launched', version }
+      return spawnInstallerHandoff(plan, deps)
+    }
+  }
+}

--- a/apps/desktop/src/main/telemetry/update-install-marker.test.ts
+++ b/apps/desktop/src/main/telemetry/update-install-marker.test.ts
@@ -16,7 +16,8 @@ vi.mock('./track', () => ({
 import {
   UPDATE_INSTALL_MARKER_FILENAME,
   detectFailedUpdateInstall,
-  markUpdateInstallStarted
+  markUpdateInstallStarted,
+  resolveUpdateInstallOutcome
 } from './update-install-marker'
 import { trackMainEvent } from './track'
 
@@ -147,5 +148,130 @@ describe('update install marker', () => {
     // #when the install handoff records its attempt
     // #then the write failure never propagates
     expect(() => markUpdateInstallStarted('2026.806.2')).not.toThrow()
+  })
+
+  describe('installer hand-off outcomes', () => {
+    it('round-trips the installer and names it as the source of a failed install', () => {
+      markUpdateInstallStarted('2026.806.2', 'v2026-08-07.2', 'velopack-handoff')
+
+      const failed = detectFailedUpdateInstall('2026.806.2', () => 'nsis')
+
+      expect(failed).toMatchObject({ fromVersion: '2026.806.2', installer: 'velopack-handoff' })
+      expect(trackMainEvent).toHaveBeenCalledWith(
+        'app_error_seen',
+        expect.objectContaining({
+          source: 'velopack-handoff',
+          errorCode: 'UPDATE_INSTALL_DID_NOT_APPLY',
+          dimensions: {
+            prior_app_version: '2026.806.2',
+            target_app_version: 'v2026-08-07.2'
+          }
+        })
+      )
+    })
+
+    it('reports a migrated install when the new build runs from the Velopack layout', () => {
+      markUpdateInstallStarted('2026.806.2', 'v2026-08-07.2', 'velopack-handoff')
+
+      const result = detectFailedUpdateInstall('2026.807.2', () => 'velopack')
+
+      expect(result).toBeNull()
+      expect(trackMainEvent).toHaveBeenCalledTimes(1)
+      expect(trackMainEvent).toHaveBeenCalledWith('app_update_installed', {
+        surface: 'updater',
+        action: 'migrated',
+        source: 'velopack-handoff',
+        result: 'success',
+        dimensions: { from_version: '2026.806.2' }
+      })
+    })
+
+    it('reports a hand-off that fell back to NSIS when the new build is not a Velopack install', () => {
+      markUpdateInstallStarted('2026.806.2', 'v2026-08-07.2', 'velopack-handoff')
+
+      const result = detectFailedUpdateInstall('2026.807.2', () => 'nsis')
+
+      expect(result).toBeNull()
+      expect(trackMainEvent).toHaveBeenCalledTimes(1)
+      expect(trackMainEvent).toHaveBeenCalledWith('app_error_seen', {
+        surface: 'app',
+        action: 'install',
+        objectType: 'exception',
+        source: 'velopack-handoff',
+        result: 'failed',
+        errorCode: 'INSTALLER_HANDOFF_DID_NOT_APPLY',
+        dimensions: { prior_app_version: '2026.806.2' }
+      })
+    })
+
+    it('reports a plain installer hand-off as before, whatever the layout', () => {
+      markUpdateInstallStarted('2026.806.2', 'v2026-08-07.2', 'electron-updater')
+
+      expect(detectFailedUpdateInstall('2026.807.2', () => 'velopack')).toBeNull()
+      expect(trackMainEvent).not.toHaveBeenCalled()
+
+      markUpdateInstallStarted('2026.806.2', 'v2026-08-07.2', 'electron-updater')
+      detectFailedUpdateInstall('2026.806.2', () => 'nsis')
+      expect(trackMainEvent).toHaveBeenCalledWith(
+        'app_error_seen',
+        expect.objectContaining({
+          source: 'electron-updater',
+          errorCode: 'UPDATE_INSTALL_DID_NOT_APPLY'
+        })
+      )
+    })
+
+    it('reads a marker written by an older build that never recorded the installer', () => {
+      fs.writeFileSync(
+        markerFile(),
+        JSON.stringify({ fromVersion: '2026.806.2', toVersion: 'v2026-08-07.2', startedAt: '' })
+      )
+
+      expect(detectFailedUpdateInstall('2026.807.2', () => 'velopack')).toBeNull()
+      expect(trackMainEvent).not.toHaveBeenCalled()
+
+      fs.writeFileSync(markerFile(), JSON.stringify({ fromVersion: '2026.806.2', startedAt: '' }))
+      const failed = detectFailedUpdateInstall('2026.806.2', () => 'nsis')
+
+      expect(failed).toEqual({ fromVersion: '2026.806.2', toVersion: undefined, startedAt: '' })
+      expect(trackMainEvent).toHaveBeenCalledWith(
+        'app_error_seen',
+        expect.objectContaining({ source: 'updater', errorCode: 'UPDATE_INSTALL_DID_NOT_APPLY' })
+      )
+    })
+
+    it('ignores an installer value it does not know', () => {
+      fs.writeFileSync(
+        markerFile(),
+        JSON.stringify({ fromVersion: '2026.806.2', startedAt: '', installer: 'squirrel' })
+      )
+
+      expect(detectFailedUpdateInstall('2026.806.2', () => 'unknown')).toEqual({
+        fromVersion: '2026.806.2',
+        toVersion: undefined,
+        startedAt: ''
+      })
+    })
+  })
+
+  describe('resolveUpdateInstallOutcome', () => {
+    const attempt = (installer?: 'electron-updater' | 'velopack' | 'velopack-handoff') => ({
+      fromVersion: '2026.806.2',
+      startedAt: '',
+      ...(installer ? { installer } : {})
+    })
+
+    it.each([
+      [attempt('velopack-handoff'), '2026.806.2', 'velopack', 'did-not-apply'],
+      [attempt('velopack-handoff'), '2026.807.2', 'velopack', 'handoff-applied'],
+      [attempt('velopack-handoff'), '2026.807.2', 'nsis', 'handoff-fell-back'],
+      [attempt('velopack-handoff'), '2026.807.2', 'unknown', 'handoff-fell-back'],
+      [attempt('electron-updater'), '2026.807.2', 'nsis', 'applied'],
+      [attempt('velopack'), '2026.807.2', 'velopack', 'applied'],
+      [attempt(), '2026.807.2', 'velopack', 'applied'],
+      [attempt(), '2026.806.2', 'unknown', 'did-not-apply']
+    ] as const)('%o on %s from a %s layout is %s', (marker, currentVersion, layout, outcome) => {
+      expect(resolveUpdateInstallOutcome(marker, currentVersion, () => layout)).toBe(outcome)
+    })
   })
 })

--- a/apps/desktop/src/main/telemetry/update-install-marker.ts
+++ b/apps/desktop/src/main/telemetry/update-install-marker.ts
@@ -15,11 +15,19 @@ import path from 'node:path'
 import { app } from 'electron'
 
 import { createLogger } from '../lib/logger'
+import type { UpdateInstaller } from '../updater-backend'
+import { detectWindowsInstallLayout, type WindowsInstallLayout } from '../windows-install-layout'
 import { trackMainEvent } from './track'
 
 const logger = createLogger('UpdateInstallMarker')
 
 export const UPDATE_INSTALL_MARKER_FILENAME = 'update-install-attempt.json'
+
+const UPDATE_INSTALLERS: ReadonlySet<string> = new Set<UpdateInstaller>([
+  'electron-updater',
+  'velopack',
+  'velopack-handoff'
+])
 
 export interface UpdateInstallAttempt {
   /**
@@ -31,22 +39,49 @@ export interface UpdateInstallAttempt {
   /** Display version being installed. Reported as-is; never compared. */
   toVersion?: string
   startedAt: string
+  /** Which installer was handed off to. Markers written by older builds lack it. */
+  installer?: UpdateInstaller
 }
 
+export type UpdateInstallOutcome =
+  'applied' | 'did-not-apply' | 'handoff-applied' | 'handoff-fell-back'
+
 const markerPath = (): string => path.join(app.getPath('userData'), UPDATE_INSTALL_MARKER_FILENAME)
+
+const parseInstaller = (value: unknown): UpdateInstaller | undefined =>
+  typeof value === 'string' && UPDATE_INSTALLERS.has(value) ? (value as UpdateInstaller) : undefined
 
 const parseAttempt = (raw: string): UpdateInstallAttempt | null => {
   try {
     const parsed = JSON.parse(raw) as Partial<UpdateInstallAttempt>
     if (!parsed || typeof parsed.fromVersion !== 'string' || !parsed.fromVersion) return null
+    const installer = parseInstaller(parsed.installer)
     return {
       fromVersion: parsed.fromVersion,
       toVersion: typeof parsed.toVersion === 'string' ? parsed.toVersion : undefined,
-      startedAt: typeof parsed.startedAt === 'string' ? parsed.startedAt : ''
+      startedAt: typeof parsed.startedAt === 'string' ? parsed.startedAt : '',
+      ...(installer ? { installer } : {})
     }
   } catch {
     return null
   }
+}
+
+/**
+ * Same version: the installer never applied. A hand-off marker that comes back on
+ * a new version proves the migration only when the app now runs from the Velopack
+ * layout; any other layout means the NSIS fallback (or a manual reinstall) is what
+ * delivered the update. The layout is read through a thunk because probing it hits
+ * the filesystem, and only a hand-off marker has any use for it.
+ */
+export const resolveUpdateInstallOutcome = (
+  attempt: UpdateInstallAttempt,
+  currentVersion: string,
+  readInstallLayout: () => WindowsInstallLayout
+): UpdateInstallOutcome => {
+  if (attempt.fromVersion === currentVersion) return 'did-not-apply'
+  if (attempt.installer !== 'velopack-handoff') return 'applied'
+  return readInstallLayout() === 'velopack' ? 'handoff-applied' : 'handoff-fell-back'
 }
 
 /**
@@ -55,12 +90,17 @@ const parseAttempt = (raw: string): UpdateInstallAttempt | null => {
  * and must never throw: losing the marker only costs a diagnostic, while
  * throwing here would break the install itself.
  */
-export const markUpdateInstallStarted = (fromVersion: string, toVersion?: string): void => {
+export const markUpdateInstallStarted = (
+  fromVersion: string,
+  toVersion?: string,
+  installer?: UpdateInstaller
+): void => {
   try {
     const attempt: UpdateInstallAttempt = {
       fromVersion,
       ...(toVersion ? { toVersion } : {}),
-      startedAt: new Date().toISOString()
+      startedAt: new Date().toISOString(),
+      ...(installer ? { installer } : {})
     }
     fs.writeFileSync(markerPath(), JSON.stringify(attempt), 'utf-8')
   } catch (error) {
@@ -79,7 +119,10 @@ export const markUpdateInstallStarted = (fromVersion: string, toVersion?: string
  * Returns the failed attempt so the caller can surface it in-app: telemetry
  * tells us, but the user is the one stuck on an old version with no idea why.
  */
-export const detectFailedUpdateInstall = (currentVersion: string): UpdateInstallAttempt | null => {
+export const detectFailedUpdateInstall = (
+  currentVersion: string,
+  readInstallLayout: () => WindowsInstallLayout = () => detectWindowsInstallLayout(process.execPath)
+): UpdateInstallAttempt | null => {
   let raw: string
   try {
     raw = fs.readFileSync(markerPath(), 'utf-8')
@@ -97,21 +140,60 @@ export const detectFailedUpdateInstall = (currentVersion: string): UpdateInstall
   // A corrupt marker proves an install was attempted but not from WHICH
   // version, and without that the applied/failed split is a coin flip.
   if (!attempt) return null
-  // Booted as a different build: the installer did its job.
-  if (attempt.fromVersion !== currentVersion) return null
+
+  const outcome = resolveUpdateInstallOutcome(attempt, currentVersion, readInstallLayout)
+  if (outcome === 'applied') return null
+
+  if (outcome === 'handoff-applied') {
+    logger.info('NSIS install migrated to Velopack', {
+      fromVersion: attempt.fromVersion,
+      toVersion: attempt.toVersion
+    })
+    trackMainEvent('app_update_installed', {
+      surface: 'updater',
+      action: 'migrated',
+      source: 'velopack-handoff',
+      result: 'success',
+      dimensions: { from_version: attempt.fromVersion }
+    })
+    return null
+  }
+
+  if (outcome === 'handoff-fell-back') {
+    // The user did get the update (NSIS fallback or manual reinstall); the
+    // migration to Velopack is what did not happen.
+    logger.warn('Velopack hand-off did not apply; the update installed through NSIS instead', {
+      fromVersion: attempt.fromVersion,
+      toVersion: attempt.toVersion,
+      layout: readInstallLayout()
+    })
+    trackMainEvent('app_error_seen', {
+      surface: 'app',
+      action: 'install',
+      objectType: 'exception',
+      source: 'velopack-handoff',
+      result: 'failed',
+      errorCode: 'INSTALLER_HANDOFF_DID_NOT_APPLY',
+      dimensions: { prior_app_version: attempt.fromVersion }
+    })
+    return null
+  }
 
   const startedAt = Date.parse(attempt.startedAt)
   const durationMs = Number.isFinite(startedAt) ? Math.max(0, Date.now() - startedAt) : undefined
 
   logger.error('update install did not apply; still running the version that started it', {
     fromVersion: attempt.fromVersion,
-    toVersion: attempt.toVersion
+    toVersion: attempt.toVersion,
+    installer: attempt.installer
   })
+  // `source` is the installer hint; the errorCode stays the same so Error
+  // Tracking keeps one issue.
   trackMainEvent('app_error_seen', {
     surface: 'app',
     action: 'install',
     objectType: 'exception',
-    source: 'updater',
+    source: attempt.installer ?? 'updater',
     result: 'failed',
     errorCode: 'UPDATE_INSTALL_DID_NOT_APPLY',
     metrics: durationMs === undefined ? undefined : { durationMs },

--- a/apps/desktop/src/main/updater-backend-electron.ts
+++ b/apps/desktop/src/main/updater-backend-electron.ts
@@ -1,7 +1,9 @@
+import { app } from 'electron'
 import { autoUpdater, type UpdateInfo } from 'electron-updater'
 import { createLogger } from './lib/logger'
 import { formatAppVersionForDisplay } from './lib/app-version-display'
 import { htmlToPlainText } from './lib/html-to-plain-text'
+import type { InstallerHandoff } from './installer-handoff'
 import { isExpiredSignedAssetError, isUpdaterCheckPhase } from './updater-error-severity'
 import { describeUpdaterError } from './updater'
 import { plainTextReleaseNotes, stripDeveloperChangelog } from './updater-release-notes'
@@ -43,7 +45,11 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 
 const logger = createLogger('Updater')
 
-export function createElectronUpdaterBackend(host: UpdaterHost): UpdaterBackend {
+export function createElectronUpdaterBackend(
+  host: UpdaterHost,
+  options: { handoff?: InstallerHandoff } = {}
+): UpdaterBackend {
+  const { handoff } = options
   /**
    * Retries still available for the in-flight check. electron-updater emits its
    * `error` event *before* checkForUpdates() rejects, so without this the first
@@ -76,7 +82,16 @@ export function createElectronUpdaterBackend(host: UpdaterHost): UpdaterBackend 
   })
 
   autoUpdater.on('update-downloaded', (info) => {
-    host.onDownloaded(toAvailableUpdate(info))
+    if (!handoff) {
+      host.onDownloaded(toAvailableUpdate(info))
+      return
+    }
+    // The host stays in `downloading` until the Velopack installer is on disk and
+    // verified (or the hand-off declined), so "Restart to install" never appears
+    // before everything the hand-off needs exists.
+    void handoff
+      .prepare(info, (percent) => host.onDownloadProgress(percent))
+      .then(() => host.onDownloaded(toAvailableUpdate(info)))
   })
 
   autoUpdater.on('error', (error) => {
@@ -102,6 +117,9 @@ export function createElectronUpdaterBackend(host: UpdaterHost): UpdaterBackend 
 
   return {
     kind: 'electron-updater',
+    get installer() {
+      return handoff?.armed() ? 'velopack-handoff' : 'electron-updater'
+    },
     /**
      * Ask again when GitHub's signed release-asset URL expired between the redirect
      * and the follow-up GET (status 618, `jwt:expired`). electron-updater does not
@@ -139,13 +157,24 @@ export function createElectronUpdaterBackend(host: UpdaterHost): UpdaterBackend 
     setInstallOnQuit(enabled: boolean): void {
       autoUpdater.autoInstallOnAppQuit = enabled
     },
+    // electron-updater installs from its own `quit` hook when autoInstallOnAppQuit
+    // is on; `will-quit` runs first, so turning the flag off here once the hand-off
+    // script is running is what stops it from ALSO running the NSIS installer.
     applyOnQuit(): void {
-      // electron-updater installs from its own `quit` hook when autoInstallOnAppQuit is on.
+      if (!autoUpdater.autoInstallOnAppQuit) return
+      if (handoff?.launch()) {
+        autoUpdater.autoInstallOnAppQuit = false
+      }
     },
     // (isSilent=true, isForceRunAfter=true): install with no visible NSIS window
     // (adds /S) and relaunch afterwards (adds --force-run). macOS Squirrel relaunches
     // regardless; the flags only affect the Windows NSIS installer.
     applyAndRestart(): void {
+      if (handoff?.launch()) {
+        autoUpdater.autoInstallOnAppQuit = false
+        app.quit()
+        return
+      }
       autoUpdater.quitAndInstall(true, true)
     }
   }

--- a/apps/desktop/src/main/updater-backend-velopack.ts
+++ b/apps/desktop/src/main/updater-backend-velopack.ts
@@ -64,6 +64,7 @@ export function createVelopackBackend(host: UpdaterHost): UpdaterBackend | null 
 
   const backend: UpdaterBackend = {
     kind: 'velopack',
+    installer: 'velopack',
     async check(): Promise<void> {
       host.onChecking()
       let info: UpdateInfo | null

--- a/apps/desktop/src/main/updater-backend.ts
+++ b/apps/desktop/src/main/updater-backend.ts
@@ -2,6 +2,9 @@ import type { UpdaterErrorPhase } from './updater'
 
 export type UpdaterBackendKind = 'electron-updater' | 'velopack'
 
+/** What the install marker records at hand-off time so the next launch knows which installer was supposed to run. */
+export type UpdateInstaller = UpdaterBackendKind | 'velopack-handoff'
+
 /**
  * Backend-neutral description of a release a check found. `version` is raw
  * (Velopack packVersion / electron-updater info.version); the host formats it

--- a/apps/desktop/src/main/updater-backend.ts
+++ b/apps/desktop/src/main/updater-backend.ts
@@ -36,6 +36,8 @@ export interface UpdaterHost {
 
 export interface UpdaterBackend {
   readonly kind: UpdaterBackendKind
+  /** The installer an install started right now would use. It changes once a hand-off is armed. */
+  readonly installer: UpdateInstaller
   /**
    * Drives onChecking → onUpdateAvailable/onUpToDate. On failure the host must have
    * been told (through host.onError, or through the backend's own event stream if it

--- a/apps/desktop/src/main/updater-nsis-handoff.test.ts
+++ b/apps/desktop/src/main/updater-nsis-handoff.test.ts
@@ -1,0 +1,364 @@
+import path from 'node:path'
+import { Readable, Writable } from 'node:stream'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  class MockEmitter {
+    private listeners = new Map<string, Array<(...args: unknown[]) => void>>()
+
+    on(event: string, listener: (...args: unknown[]) => void): this {
+      const listeners = this.listeners.get(event) ?? []
+      listeners.push(listener)
+      this.listeners.set(event, listeners)
+      return this
+    }
+
+    emit(event: string, ...args: unknown[]): boolean {
+      for (const listener of this.listeners.get(event) ?? []) {
+        listener(...args)
+      }
+      return true
+    }
+
+    removeAllListeners(): this {
+      this.listeners.clear()
+      return this
+    }
+  }
+
+  const storeState: {
+    prefs: { skippedVersion?: string; autoDownload?: boolean; autoCheck?: boolean }
+  } = { prefs: {} }
+  const child = { unref: vi.fn(), on: vi.fn() }
+
+  return {
+    storeState,
+    store: {
+      getUpdaterPrefs: vi.fn(() => storeState.prefs),
+      setSkippedVersion: vi.fn(),
+      setAutoDownloadPref: vi.fn(),
+      setAutoCheckPref: vi.fn()
+    },
+    app: Object.assign(new MockEmitter(), {
+      isPackaged: true,
+      getVersion: vi.fn(() => '1.2.3'),
+      getPath: vi.fn(() => 'C:\\Users\\kaan\\AppData\\Roaming\\memrynote'),
+      quit: vi.fn(),
+      isInApplicationsFolder: vi.fn(() => true)
+    }),
+    windows: [
+      Object.assign(new MockEmitter(), {
+        isDestroyed: () => false,
+        webContents: {
+          isDestroyed: () => false,
+          send: vi.fn()
+        }
+      })
+    ],
+    installHealth: {
+      recordUpdateInstallFailure: vi.fn(),
+      reconcileUpdateInstallHealth: vi.fn()
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn()
+    },
+    autoUpdater: Object.assign(new MockEmitter(), {
+      autoDownload: true,
+      autoInstallOnAppQuit: false,
+      checkForUpdates: vi.fn(),
+      downloadUpdate: vi.fn(),
+      quitAndInstall: vi.fn()
+    }),
+    child,
+    childProcess: {
+      execFile: vi.fn(),
+      spawn: vi.fn(() => child)
+    },
+    fs: {
+      existsSync: vi.fn((p: unknown) => String(p).endsWith('Uninstall MemryNote.exe')),
+      mkdirSync: vi.fn(),
+      rmSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      copyFileSync: vi.fn(),
+      createWriteStream: vi.fn()
+    },
+    fetch: vi.fn()
+  }
+})
+
+vi.mock('electron', () => ({
+  app: mocks.app,
+  BrowserWindow: {
+    getAllWindows: () => mocks.windows
+  }
+}))
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: mocks.autoUpdater
+}))
+
+vi.mock('./velopack-native', () => ({
+  loadVelopack: () => ({
+    UpdateManager: class {
+      constructor() {
+        throw new Error('This application is not properly installed')
+      }
+    }
+  })
+}))
+
+vi.mock('node:child_process', () => mocks.childProcess)
+vi.mock('node:fs', () => ({ default: mocks.fs, ...mocks.fs }))
+vi.mock('node:os', () => ({ tmpdir: () => 'C:\\Users\\kaan\\AppData\\Local\\Temp' }))
+
+vi.mock('./store', () => ({
+  getUpdaterPrefs: mocks.store.getUpdaterPrefs,
+  setSkippedVersion: mocks.store.setSkippedVersion,
+  setAutoDownloadPref: mocks.store.setAutoDownloadPref,
+  setAutoCheckPref: mocks.store.setAutoCheckPref
+}))
+
+vi.mock('./lib/logger', () => ({
+  createLogger: () => mocks.logger
+}))
+
+vi.mock('./lib/main-i18n', () => ({
+  getMainI18n: () => ({
+    t: (key: string) => key,
+    getFixedT: () => (key: string) => key
+  })
+}))
+
+vi.mock('./lib/app-version-display', () => ({
+  formatAppVersionForDisplay: (version: string) => `v${version}`
+}))
+
+vi.mock('./telemetry/diagnostics', () => ({
+  trackMainError: vi.fn(),
+  trackMainWarning: vi.fn()
+}))
+vi.mock('./telemetry/track', () => ({
+  trackMainEvent: vi.fn()
+}))
+vi.mock('./telemetry/update-install-marker', () => ({
+  markUpdateInstallStarted: vi.fn()
+}))
+vi.mock('./updater-install-health', () => ({
+  recordUpdateInstallFailure: mocks.installHealth.recordUpdateInstallFailure,
+  reconcileUpdateInstallHealth: mocks.installHealth.reconcileUpdateInstallHealth
+}))
+
+import { markUpdateInstallStarted } from './telemetry/update-install-marker'
+
+const SETUP_URL =
+  'https://github.com/memrynote/memry/releases/download/v2026-09-11.1/MemryNote-win-Setup.exe'
+const VALID_SIGNATURE = JSON.stringify({
+  Status: 0,
+  SignerCertificate: { Subject: 'CN=Open Source Developer Kaan Karaca, C=TR' }
+})
+
+const realPlatform = process.platform
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true })
+}
+
+async function loadUpdater() {
+  vi.resetModules()
+  return import('./updater')
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
+function response(status: number, body?: Readable): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(body ? { 'content-length': '4' } : {}),
+    body
+  } as unknown as Response
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+const downloadedInfo = {
+  version: '1.2.4',
+  tag: 'v2026-09-11.1',
+  files: [{ url: 'MemryNote-1.2.4-setup.exe', sha512: 'sha' }],
+  path: 'MemryNote-1.2.4-setup.exe',
+  sha512: 'sha',
+  releaseDate: '2026-09-11',
+  downloadedFile:
+    'C:\\Users\\kaan\\AppData\\Local\\memrynote-updater\\pending\\MemryNote-1.2.4-setup.exe'
+}
+
+function serveVelopackAsset(head: Response = response(200)): void {
+  mocks.fetch.mockImplementation(async (_url: string, init?: RequestInit) =>
+    init?.method === 'HEAD' ? head : response(200, Readable.from([Buffer.from('abcd')]))
+  )
+}
+
+async function loadWithDownloadedUpdate() {
+  const updater = await loadUpdater()
+  updater.initializeUpdater()
+  mocks.autoUpdater.emit('update-downloaded', downloadedInfo)
+  await vi.waitFor(() => {
+    expect(updater.getUpdateState().status).toBe('downloaded')
+  })
+  return updater
+}
+
+describe('NSIS to Velopack hand-off through the updater', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setPlatform('win32')
+    vi.stubGlobal('fetch', mocks.fetch)
+    mocks.storeState.prefs = {}
+    mocks.autoUpdater.removeAllListeners()
+    mocks.app.removeAllListeners()
+    mocks.windows[0].removeAllListeners()
+    mocks.autoUpdater.autoDownload = true
+    mocks.autoUpdater.autoInstallOnAppQuit = false
+    mocks.autoUpdater.checkForUpdates.mockResolvedValue(undefined)
+    mocks.app.isPackaged = true
+    mocks.app.getVersion.mockReturnValue('1.2.3')
+    mocks.installHealth.recordUpdateInstallFailure.mockReturnValue({
+      consecutiveFailures: 1,
+      stuck: false
+    })
+    mocks.installHealth.reconcileUpdateInstallHealth.mockReturnValue(null)
+    mocks.fs.existsSync.mockImplementation((p: unknown) =>
+      String(p).endsWith('Uninstall MemryNote.exe')
+    )
+    mocks.fs.createWriteStream.mockImplementation(
+      () =>
+        new Writable({
+          write(_chunk, _encoding, callback) {
+            callback()
+          }
+        })
+    )
+    mocks.childProcess.spawn.mockReturnValue(mocks.child)
+    mocks.childProcess.execFile.mockImplementation(
+      (
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        callback(null, VALID_SIGNATURE, '')
+      }
+    )
+    serveVelopackAsset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    setPlatform(realPlatform)
+  })
+
+  it('wires the hand-off into the electron-updater backend on an NSIS install', async () => {
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+
+    expect(mocks.logger.info).toHaveBeenCalledWith('updater backend selected', {
+      backend: 'electron-updater'
+    })
+    mocks.autoUpdater.emit('update-downloaded', downloadedInfo)
+    await flushAsyncWork()
+
+    expect(mocks.fetch).toHaveBeenCalledWith(SETUP_URL, { method: 'HEAD' })
+  })
+
+  it('holds the state at downloading until the hand-off is prepared', async () => {
+    const head = deferred<Response>()
+    mocks.fetch.mockImplementation(async () => head.promise)
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+    mocks.autoUpdater.emit('download-progress', { percent: 100 })
+
+    mocks.autoUpdater.emit('update-downloaded', downloadedInfo)
+    await flushAsyncWork()
+    expect(updater.getUpdateState().status).toBe('downloading')
+
+    head.resolve(response(404))
+    await vi.waitFor(() => {
+      expect(updater.getUpdateState().status).toBe('downloaded')
+    })
+    expect(updater.getUpdateState().availableVersion).toBe('v1.2.4')
+  })
+
+  it('hands the Restart-to-install path to the Velopack script instead of the NSIS installer', async () => {
+    const updater = await loadWithDownloadedUpdate()
+
+    updater.quitAndInstall()
+    expect(mocks.app.quit).toHaveBeenCalledTimes(1)
+    updater.performQuitAndInstall()
+
+    expect(markUpdateInstallStarted).toHaveBeenCalledWith('1.2.3', 'v1.2.4', 'velopack-handoff')
+    const scriptPath = path.win32.join(
+      'C:\\Users\\kaan\\AppData\\Local\\Temp',
+      `memry-installer-handoff-${process.pid}.cmd`
+    )
+    expect(mocks.childProcess.spawn).toHaveBeenCalledWith('cmd.exe', ['/c', scriptPath], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true
+    })
+    expect(vi.mocked(markUpdateInstallStarted).mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.childProcess.spawn.mock.invocationCallOrder[0]
+    )
+    expect(mocks.child.unref).toHaveBeenCalled()
+    expect(mocks.autoUpdater.autoInstallOnAppQuit).toBe(false)
+    expect(mocks.app.quit).toHaveBeenCalledTimes(2)
+    expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('keeps the NSIS install when the release carries no Velopack installer', async () => {
+    serveVelopackAsset(response(404))
+    const updater = await loadWithDownloadedUpdate()
+
+    updater.quitAndInstall()
+    updater.performQuitAndInstall()
+
+    expect(markUpdateInstallStarted).toHaveBeenCalledWith('1.2.3', 'v1.2.4', 'electron-updater')
+    expect(mocks.childProcess.spawn).not.toHaveBeenCalled()
+    expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true)
+  })
+
+  it('writes the marker and launches the script on a normal quit with install-on-quit', async () => {
+    await loadWithDownloadedUpdate()
+    expect(mocks.autoUpdater.autoInstallOnAppQuit).toBe(true)
+
+    mocks.app.emit('will-quit')
+
+    expect(markUpdateInstallStarted).toHaveBeenCalledWith('1.2.3', 'v1.2.4', 'velopack-handoff')
+    expect(mocks.childProcess.spawn).toHaveBeenCalledWith(
+      'cmd.exe',
+      expect.any(Array),
+      expect.objectContaining({ detached: true })
+    )
+    expect(mocks.autoUpdater.autoInstallOnAppQuit).toBe(false)
+  })
+
+  it('does not launch the script when the OS session is ending', async () => {
+    await loadWithDownloadedUpdate()
+
+    mocks.windows[0].emit('query-session-end')
+    mocks.app.emit('will-quit')
+
+    expect(markUpdateInstallStarted).not.toHaveBeenCalled()
+    expect(mocks.childProcess.spawn).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/updater-velopack.test.ts
+++ b/apps/desktop/src/main/updater-velopack.test.ts
@@ -114,6 +114,16 @@ vi.mock('./velopack-native', () => ({
   loadVelopack: () => ({ UpdateManager: mocks.UpdateManager })
 }))
 
+// The NSIS fallback path constructs the hand-off, which reads userData and the
+// filesystem; its own behaviour is covered in updater-nsis-handoff.test.ts.
+vi.mock('./installer-handoff', () => ({
+  createInstallerHandoff: () => ({
+    prepare: async () => {},
+    armed: () => false,
+    launch: () => false
+  })
+}))
+
 vi.mock('./store', () => ({
   getUpdaterPrefs: mocks.store.getUpdaterPrefs,
   setSkippedVersion: mocks.store.setSkippedVersion,
@@ -491,7 +501,7 @@ describe('velopack updater backend', () => {
 
       updater.performQuitAndInstall()
 
-      expect(markUpdateInstallStarted).toHaveBeenCalledWith('1.2.3', 'v1.2.4')
+      expect(markUpdateInstallStarted).toHaveBeenCalledWith('1.2.3', 'v1.2.4', 'velopack')
       expect(vi.mocked(markUpdateInstallStarted).mock.invocationCallOrder[0]).toBeLessThan(
         mocks.velopack.waitExitThenApplyUpdate.mock.invocationCallOrder[0]
       )

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -119,6 +119,16 @@ vi.mock('./velopack-native', () => ({
   })
 }))
 
+// The NSIS hand-off reads userData and the filesystem at construction; its own
+// behaviour is covered in updater-nsis-handoff.test.ts.
+vi.mock('./installer-handoff', () => ({
+  createInstallerHandoff: () => ({
+    prepare: async () => {},
+    armed: () => false,
+    launch: () => false
+  })
+}))
+
 vi.mock('./store', () => ({
   getUpdaterPrefs: mocks.store.getUpdaterPrefs,
   setSkippedVersion: mocks.store.setSkippedVersion,
@@ -1001,7 +1011,7 @@ describe('updater', () => {
 
     // Raw app version (comparable on the next launch) + the display version of
     // the build being installed.
-    expect(markUpdateInstallStarted).toHaveBeenCalledWith('1.2.3', 'v1.2.7')
+    expect(markUpdateInstallStarted).toHaveBeenCalledWith('1.2.3', 'v1.2.7', 'electron-updater')
     // The marker must land BEFORE the handoff: afterwards the process is gone.
     expect(vi.mocked(markUpdateInstallStarted).mock.invocationCallOrder[0]).toBeLessThan(
       mocks.autoUpdater.quitAndInstall.mock.invocationCallOrder[0]

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -5,6 +5,7 @@ import { createLogger } from './lib/logger'
 import { broadcastToAllWindows } from './lib/window-broadcast'
 import { getMainI18n } from './lib/main-i18n'
 import { formatAppVersionForDisplay } from './lib/app-version-display'
+import { createInstallerHandoff } from './installer-handoff'
 import { getUpdaterPrefs, setAutoCheckPref, setAutoDownloadPref, setSkippedVersion } from './store'
 import { trackMainError, trackMainWarning } from './telemetry/diagnostics'
 import { trackMainEvent } from './telemetry/track'
@@ -353,9 +354,8 @@ const host: UpdaterHost = {
 }
 
 /**
- * One decision, once. Windows packaged builds prefer Velopack; every other platform,
- * and a Windows install that is not a Velopack install (NSIS), stays on
- * electron-updater unchanged.
+ * One decision, once. Windows packaged builds prefer Velopack; every other platform
+ * stays on electron-updater unchanged.
  */
 function selectUpdaterBackend(host: UpdaterHost): UpdaterBackend {
   if (process.platform === 'win32') {
@@ -363,6 +363,9 @@ function selectUpdaterBackend(host: UpdaterHost): UpdaterBackend {
     if (velopack) {
       return velopack
     }
+    // An NSIS install. electron-updater keeps checking and downloading; the install
+    // step migrates to Velopack when the release carries its installer.
+    return createElectronUpdaterBackend(host, { handoff: createInstallerHandoff(host) })
   }
   return createElectronUpdaterBackend(host)
 }
@@ -447,6 +450,15 @@ export function initializeUpdater(): void {
   // performQuitAndInstall() instead, which must not install twice.
   app.on('will-quit', () => {
     if (state.status === 'downloaded' && !quitAndInstallRequested) {
+      // Same marker as the Restart path, written before the hand-off: the
+      // installer runs after this process exits, so this is the last evidence.
+      if (!installOnQuitDisabledForSessionEnd) {
+        markUpdateInstallStarted(
+          getCurrentVersion(),
+          state.availableVersion ?? undefined,
+          backend?.installer
+        )
+      }
       backend?.applyOnQuit()
     }
   })
@@ -667,7 +679,11 @@ export function performQuitAndInstall(): void {
   // and the shutdown chain has already disposed the telemetry runtime and the
   // log-ship transport, so an install failure from here on reaches nobody. The
   // next launch reads this marker and reports the install that never applied.
-  markUpdateInstallStarted(getCurrentVersion(), state.availableVersion ?? undefined)
+  markUpdateInstallStarted(
+    getCurrentVersion(),
+    state.availableVersion ?? undefined,
+    backend?.installer
+  )
   backend?.applyAndRestart()
 }
 

--- a/apps/desktop/src/main/windows-install-layout.ts
+++ b/apps/desktop/src/main/windows-install-layout.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export type WindowsInstallLayout = 'nsis' | 'velopack' | 'unknown'
+
+export const NSIS_UNINSTALLER_FILENAME = 'Uninstall MemryNote.exe'
+
+/**
+ * velopack: `<dir>\..\Update.exe` exists; nsis: `<dir>\Uninstall MemryNote.exe`
+ * exists; else unknown. Windows paths by definition, so `path.win32` keeps the
+ * probe paths identical on the macOS test host.
+ */
+export function detectWindowsInstallLayout(
+  execPath: string,
+  exists: (p: string) => boolean = fs.existsSync
+): WindowsInstallLayout {
+  const dir = path.win32.dirname(execPath)
+  if (exists(path.win32.join(dir, '..', 'Update.exe'))) return 'velopack'
+  if (exists(path.win32.join(dir, NSIS_UNINSTALLER_FILENAME))) return 'nsis'
+  return 'unknown'
+}

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -1111,6 +1111,34 @@ reason, phase, mode, status, kind, result`, plus numeric metric keys like
   to `Update.exe` and read on the next launch, and an `install`-phase failure advances the streak
   exactly as above. Velopack does no download-time staging, so it never produces the
   `downloaded`-phase attempts Squirrel.Mac does.
+  The marker also records which installer was handed off to (`installer`:
+  `electron-updater`, `velopack`, or `velopack-handoff`), and the silent install-on-quit path
+  writes it too, so a Windows update that applies on a normal quit and never comes back is no longer
+  invisible.
+- **NSIS to Velopack hand-off**: a Windows install made by the older NSIS installer keeps
+  electron-updater for checking and downloading. Once the NSIS `setup.exe` is on disk,
+  `apps/desktop/src/main/installer-handoff.ts` looks for `MemryNote-win-Setup.exe` on the same
+  release tag (`HEAD`, then a streamed download into `userData/installer-handoff/`, folded into the
+  `downloading` state) and verifies it with `Get-AuthenticodeSignature`: status `Valid` and a signer
+  subject containing `CN=Open Source Developer Kaan Karaca`, or the file is deleted and never run.
+  The install step then spawns a detached batch script (rendered by
+  `installer-handoff-script.ts`, so its exact command lines are pinned by tests) that waits for the
+  app's PID to exit, runs a copy of `Uninstall MemryNote.exe /S _?=INSTALLDIR` (no `--updated`,
+  so the tolerant removal path runs, and the copy blocks until the old install, its shortcuts and
+  its uninstall key are gone), runs `MemryNote-win-Setup.exe --silent --verbose --log userData/logs/velopack-setup.log`, and
+  falls back to the already-downloaded NSIS installer if no
+  Velopack `Memrynote.exe` exists afterwards, so the user is never left without an app. Every
+  refusal falls back to the plain NSIS install: a release without the Velopack asset (info log
+  only), a download failure (`INSTALLER_HANDOFF_DOWNLOAD_FAILED` through the updater error path) and
+  a signature failure (`INSTALLER_HANDOFF_UNVERIFIED`). The next launch reads the marker: still the
+  same version is the usual `UPDATE_INSTALL_DID_NOT_APPLY` with `source: velopack-handoff`; a new
+  version running from the Velopack layout (`..\Update.exe` next to the app) is
+  `app_update_installed` with `action: migrated` and `source: velopack-handoff`; a new version
+  still running from an NSIS layout is `INSTALLER_HANDOFF_DID_NOT_APPLY`, meaning the update
+  arrived but the migration did not. `Memrynote.exe --cli migrate-installer path\to\MemryNote-win-Setup.exe`
+  drives the same verify-then-hand-off path against a local file (exit 0 when scheduled, 1
+  otherwise, Windows only), which is what the `migrate` job in
+  `.github/workflows/velopack-smoke.yml` runs on a real NSIS install.
 - **Expired GitHub signed asset URLs**: GitHub serves a release asset by redirecting to a
   short-lived signed `release-assets.githubusercontent.com` URL. When the follow-up GET lands after
   that token expires, GitHub answers with the non-standard status **618 `jwt:expired`**, and

--- a/apps/docs/src/guide/install.md
+++ b/apps/docs/src/guide/install.md
@@ -61,13 +61,21 @@ anything interrupts the install, including shutting the PC down mid-update. For 
 reason, an update is no longer installed while Windows itself is shutting down; it
 simply applies the next time you quit the app.
 
-One caveat if you are already affected. On Windows the step that removes the old files
-is run by the version you currently have installed, not by the one being installed — so
-these workarounds only take effect on updates _away from_ a build that contains them. If
-your updates are failing today, install the latest version manually once
-(uninstall from **Settings → Apps**, then run the installer from
-[the download page](https://memrynote.com/download/desktop); your vault and settings are kept).
-Updates after that run on their own.
+An install under `%LOCALAPPDATA%\Programs\MemryNote` came from the earlier installer. It
+moves to the new installer on its own, once, on the next update: the app downloads the
+new installer alongside the update, checks its signature, and after you quit it removes
+the old install and installs the new one in `%LOCALAPPDATA%\MemryNote`. Your vault,
+settings and search index stay where they are. There is nothing to do, and the app opens
+again by itself when the switch is done. The Start menu entry comes back at the same
+place; a memrynote pin on the taskbar may need to be pinned again, once.
+
+If the release you are updating to does not carry the new installer yet, the update
+installs the way it always has. An update there can be blocked by a file in the install
+folder being held open, usually antivirus or a leftover memrynote process. The installer
+works around that on its own.
+
+On either one, an update is never installed while Windows itself is shutting down. It
+applies the next time you quit the app.
 
 ## Run from Source
 


### PR DESCRIPTION
## Summary

A Windows user on an NSIS install currently stays on the update path that fails on roughly 8.5% of installs per 60 days. This moves them to the Velopack install automatically, on the next update they take, with no prompt and no manual reinstall.

An NSIS install keeps electron-updater for checking and downloading. The install step is what changes. Once electron-updater has the NSIS `setup.exe` on disk, `installer-handoff.ts` looks for `MemryNote-win-Setup.exe` on the same release tag, streams it into `userData/installer-handoff/`, and verifies it before anything is executed. `onDownloaded` is deferred until that settles, so "Restart to install" never appears before everything the hand-off needs exists.

**Verification rule.** `Get-AuthenticodeSignature -LiteralPath <file> | ConvertTo-Json -Compress`, parsed by `judgeAuthenticode`. Status must be `Valid` (serialized as `0` or the enum name) and `SignerCertificate.Subject` must contain `CN=Open Source Developer Kaan Karaca`. Anything else deletes the file and declines. An unverified binary is never spawned, on either the updater path or the CLI path.

**The hand-off script.** Pinned by `installer-handoff-script.test.ts`, rendered with CRLF, spawned detached through `cmd.exe /c`:

```bat
@echo off
setlocal
rem MemryNote installer hand-off: wait for the app to exit, remove the NSIS install, install the Velopack build.
set "APP_PID=1234"
set "APP_EXE=Memrynote.exe"
set "INSTALL_DIR=C:\Users\kaan\AppData\Local\Programs\MemryNote"
set "UNINSTALLER=C:\Users\kaan\AppData\Local\Programs\MemryNote\Uninstall MemryNote.exe"
set "WORK_DIR=C:\Users\kaan\AppData\Local\Temp\memry-installer-handoff-1234"
set "SETUP=C:\Users\kaan\AppData\Roaming\memrynote\installer-handoff\MemryNote-win-Setup.exe"
set "SETUP_LOG=C:\Users\kaan\AppData\Roaming\memrynote\logs\velopack-setup.log"
set "NSIS_INSTALLER=C:\Users\kaan\AppData\Local\memrynote-updater\pending\MemryNote-2026.911.1-setup.exe"
set "VELOPACK_EXE=%LocalAppData%\MemryNote\current\Memrynote.exe"

:wait_for_exit
tasklist /FI "PID eq %APP_PID%" /FI "IMAGENAME eq %APP_EXE%" /NH 2>nul | find /I "%APP_EXE%" >nul
if not errorlevel 1 (
  ping -n 2 127.0.0.1 >nul
  goto wait_for_exit
)

if not exist "%WORK_DIR%" mkdir "%WORK_DIR%"
copy /y "%UNINSTALLER%" "%WORK_DIR%\Uninstall MemryNote.exe" >nul
start "" /wait "%WORK_DIR%\Uninstall MemryNote.exe" /S _?=%INSTALL_DIR%

start "" /wait "%SETUP%" --silent --verbose --log "%SETUP_LOG%"

if not exist "%VELOPACK_EXE%" (
  if exist "%NSIS_INSTALLER%" start "" /wait "%NSIS_INSTALLER%" /S --force-run
)

del /q "%SETUP%" >nul 2>&1
rmdir /s /q "%WORK_DIR%" >nul 2>&1
(goto) 2>nul & del "%~f0"
```

Order matters in four places. It waits for our own PID *and* image name, so a recycled PID cannot match. `ping` is the sleep because `timeout /t` aborts with "Input redirection is not supported" under `stdio: 'ignore'`. The uninstaller runs from a copy with `_?=` last and unquoted, so it blocks and `RMDir /r $INSTDIR` can remove the original, and without `--updated`, so the tolerant full-removal path runs and the Start-menu shortcut at the path Velopack is about to reuse is gone first. Setup.exe runs only after that, and launches the app itself.

**Fallbacks.** Every refusal lands on the plain NSIS install, which is exactly today's behavior.

| What fails | What the user sees |
| --- | --- |
| The release carries no `MemryNote-win-Setup.exe` (`HEAD` 404) | Nothing. Info log only, no error event. The NSIS update installs as usual. |
| `HEAD` or the download fails | Nothing new. `INSTALLER_HANDOFF_DOWNLOAD_FAILED` through the existing updater error path, then the NSIS update installs as usual. |
| The signature does not verify | Same. `INSTALLER_HANDOFF_UNVERIFIED`, the downloaded file is deleted, the NSIS update installs as usual. |
| The script cannot be spawned | `launch()` returns false, so `autoInstallOnAppQuit` is left on and electron-updater installs the NSIS update from its own quit hook. |
| Setup.exe runs but leaves no app | The script reinstalls from the NSIS installer electron-updater already downloaded. The user is never left without an app. |
| Windows itself is shutting down | No install at all, hand-off included, which is the existing `session-end` guard. It applies on the next user-initiated quit. |

**Next launch.** The marker now carries `installer` (`electron-updater`, `velopack`, `velopack-handoff`; older markers lack the field). `resolveUpdateInstallOutcome` reads it against the running version and the install layout. Same version is the existing `UPDATE_INSTALL_DID_NOT_APPLY`, now with `source: velopack-handoff`. A new version from the Velopack layout is `app_update_installed` with `action: migrated`. A new version still on the NSIS layout is `INSTALLER_HANDOFF_DID_NOT_APPLY`, meaning the update arrived but the migration did not. The silent install-on-quit path writes the marker too, which it never did before, so a Windows update that applies on a normal quit is no longer invisible.

`Memrynote.exe --cli migrate-installer <path-to-MemryNote-win-Setup.exe>` drives the same verify-then-hand-off path against a local file. Windows only, exit 0 only once the script is spawned.

Stacked on #2164.

## Release note

none

## Test plan

Run from the worktree on Node 24 (`.nvmrc`), unless noted.

- `pnpm --filter @memry/desktop typecheck:node` — pass.
- `pnpm --filter @memry/desktop typecheck:test` — pass. No test file was added to the `tsconfig.test.*.json` exclude backlog.
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/installer-handoff.test.ts src/main/installer-handoff-script.test.ts src/main/updater-nsis-handoff.test.ts src/main/cli/migrate-installer.test.ts src/main/telemetry/update-install-marker.test.ts src/main/cli/headless.test.ts src/main/updater.test.ts src/main/updater-velopack.test.ts` — 134 pass.
- `pnpm --filter @memry/desktop test:main` — 8263 pass, 3 fail. The three are `apps/desktop/scripts/check-cert-hashes-config.test.ts`, which passes on Node 24 and only fails when the suite runs on the Node 26 the native modules happen to be built for here. Unrelated to this diff.
- `pnpm lint` — 0 errors. The one warning is pre-existing in `vault-switcher.tsx`.
- `pnpm check:architecture`, `pnpm check:contracts` — pass.
- `pnpm ipc:check` — pass on Node 24. No contract changed. On Node 26 it dies on `--experimental-transform-types`, which that version removed.
- `pnpm docs:impact --base origin/feat/velopack-windows-updater --strict` — pass, docs changed on this branch.
- `pnpm docs:build`, `git diff --check` — pass.

What none of that covers: the batch script, the `_?=` uninstaller behavior and the `Get-AuthenticodeSignature | ConvertTo-Json` shape only ever run on Windows, so every test here asserts the rendered text and the parse rules rather than the effect. The `migrate` job in `.github/workflows/velopack-smoke.yml` is what proves them, and it needs a published release carrying `MemryNote-win-Setup.exe` before it can run. It installs the published NSIS build, hands off, then asserts the NSIS directory, its uninstall key and its shortcut are gone, the Velopack install is signed and present, the Start menu entry is back and `Memrynote.exe` is running from the new install. Its `run_cli_migration` input stays off until a published NSIS build contains `migrate-installer`. The hand-off is also unverified end to end against a real update until that release exists.
