### PR TITLE
chore(release): pack Windows with the VelopackApp check on

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -69,7 +69,7 @@ const keychainService = 'memry-sign-pin'
 // Velopack refuses to pack an app that never calls VelopackApp.build().run().
 // The app-side updater ships in its own change; flip this to false in the same
 // release that ships it.
-const skipVeloAppCheck = true
+const skipVeloAppCheck = false
 
 async function runCli() {
   const options = parseReleaseArgs(process.argv.slice(2))


### PR DESCRIPTION
## Summary
The app now calls VelopackApp.build().run() on packaged Windows (#2164), so vpk pack no longer needs --skipVeloAppCheck. Flips the one-line switch left in scripts/release.mjs by #2162.

## Verification
node --test scripts/velopack-release-utils.test.mjs passes.