### PR TITLE
feat(editor): insert a template below a block from its handle

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -1306,7 +1306,7 @@ describe('ContentArea', () => {
           noteTitle: 'My note',
           notePath: 'Notes/My note.md',
           referenceBlockId: 'url-block',
-          consumeEmptyReference: true
+          placement: 'replace-if-empty'
         })
       )
     )

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -91,7 +91,7 @@ import {
   type AttachmentKind,
   type InsertedAttachment
 } from './attachment-picker-dialog'
-import { insertTemplateBlocks } from './insert-template'
+import { insertTemplateBlocks, type TemplateAnchor } from './insert-template'
 import { TemplateSelector } from '@/components/note/template-selector'
 import { useTemplates } from '@/hooks/use-templates'
 import { createMultiBlockIndentPlugin } from './multi-block-indent-plugin'
@@ -1479,10 +1479,10 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   }, [])
 
   const { templates: templateList, getTemplate } = useTemplates()
-  const [templateAnchorBlockId, setTemplateAnchorBlockId] = useState<string | null>(null)
+  const [templateAnchor, setTemplateAnchor] = useState<TemplateAnchor | null>(null)
 
   const insertTemplate = useCallback(
-    async (templateId: string, referenceBlockId: string): Promise<void> => {
+    async (templateId: string, anchor: TemplateAnchor): Promise<void> => {
       try {
         const template = await getTemplate(templateId)
         if (!template) {
@@ -1494,8 +1494,8 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
           editor,
           content: template.content,
           noteTitle: note?.title ?? '',
-          referenceBlockId,
-          consumeEmptyReference: true,
+          referenceBlockId: anchor.blockId,
+          placement: anchor.placement,
           notePath: note?.path
         })
         if (!result.ok) {
@@ -1588,6 +1588,10 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
 
   const requestBlockMove = useCallback((blockId: string) => {
     setMoveBlockId(blockId)
+  }, [])
+
+  const requestTemplateInsert = useCallback((anchor: TemplateAnchor) => {
+    setTemplateAnchor(anchor)
   }, [])
 
   const moveBlockToNote = useCallback(
@@ -1859,14 +1863,14 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
               }}
             />
           )}
-          {templateAnchorBlockId && (
+          {templateAnchor && (
             <TemplateSelector
               isOpen
               applyMode
-              onClose={() => setTemplateAnchorBlockId(null)}
+              onClose={() => setTemplateAnchor(null)}
               onSelect={(templateId) => {
-                setTemplateAnchorBlockId(null)
-                if (templateId) void insertTemplate(templateId, templateAnchorBlockId)
+                setTemplateAnchor(null)
+                if (templateId) void insertTemplate(templateId, templateAnchor)
               }}
             />
           )}
@@ -2017,6 +2021,7 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
             <BlockSideMenuController
               onAddComment={review?.onAddComment}
               onRequestMove={requestBlockMove}
+              onRequestInsertTemplate={requestTemplateInsert}
               floatingUIOptions={{
                 useFloatingOptions: { middleware: [BULLET_FOLD_HANDLE_OFFSET] }
               }}
@@ -2164,7 +2169,10 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
                 const insertTemplateItem = {
                   title: t('editor.slashMenu.insertTemplate.title'),
                   onItemClick: () =>
-                    setTemplateAnchorBlockId(editor.getTextCursorPosition().block.id),
+                    setTemplateAnchor({
+                      blockId: editor.getTextCursorPosition().block.id,
+                      placement: 'replace-if-empty'
+                    }),
                   aliases: ['template', 'templates', 'snippet', 'insert'],
                   group: 'Basic blocks',
                   subtext: t('editor.slashMenu.insertTemplate.subtext')
@@ -2174,7 +2182,10 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
                     ? templateList.map((template) => ({
                         title: template.name,
                         onItemClick: () =>
-                          void insertTemplate(template.id, editor.getTextCursorPosition().block.id),
+                          void insertTemplate(template.id, {
+                            blockId: editor.getTextCursorPosition().block.id,
+                            placement: 'replace-if-empty'
+                          }),
                         aliases: [] as string[],
                         group: t('editor.slashMenu.insertTemplate.group'),
                         subtext: template.description

--- a/apps/desktop/src/renderer/src/components/note/content-area/block-side-menu.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/block-side-menu.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BlockSideMenuController } from './block-side-menu'
+
+const state = vi.hoisted(() => ({
+  block: undefined as { id: string; type: string; content: unknown } | undefined
+}))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'editor.blockMenu.turnInto': 'Turn into',
+        'editor.blockMenu.turnIntoTypes.paragraph': 'Text',
+        'editor.blockMenu.colors': 'Colors',
+        'editor.blockMenu.duplicate': 'Duplicate',
+        'editor.blockMenu.insertTemplate': 'Insert template…',
+        'editor.blockMenu.moveTo': 'Move to…',
+        'editor.blockMenu.delete': 'Delete',
+        'editor.blockMenu.comment': 'Comment'
+      }
+      return messages[key] ?? key
+    }
+  })
+}))
+
+vi.mock('@blocknote/core/extensions', () => ({ SideMenuExtension: { name: 'sideMenu' } }))
+
+vi.mock('./review-formatting-toolbar', () => ({
+  getEditorSelectionFromState: vi.fn(() => null),
+  getProseMirrorState: vi.fn(() => null)
+}))
+
+vi.mock('@blocknote/react', () => ({
+  BlockColorsItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  RemoveBlockItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SideMenu: ({ dragHandleMenu: DragHandleMenu }: { dragHandleMenu: React.FC }) => (
+    <DragHandleMenu />
+  ),
+  SideMenuController: ({ sideMenu: SideMenuComponent }: { sideMenu: React.FC }) => (
+    <SideMenuComponent />
+  ),
+  useBlockNoteEditor: () => ({ schema: { blockSchema: { paragraph: {} } } }),
+  useComponentsContext: () => ({
+    Generic: {
+      Menu: {
+        Root: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+        Trigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+        Dropdown: ({ children }: { children: React.ReactNode }) => (
+          <div role="menu">{children}</div>
+        ),
+        Divider: () => <hr />,
+        Item: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+          <button type="button" role="menuitem" onClick={onClick}>
+            {children}
+          </button>
+        )
+      }
+    }
+  }),
+  useExtensionState: () => state.block
+}))
+
+function menuItemNames(): string[] {
+  return screen.getAllByRole('menuitem').map((item) => item.textContent?.trim() ?? '')
+}
+
+describe('BlockSideMenuController insert template item', () => {
+  beforeEach(() => {
+    state.block = {
+      id: 'block-1',
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Hovered line' }]
+    }
+  })
+
+  it('sits between Duplicate and Move to in the menu', () => {
+    render(<BlockSideMenuController onRequestMove={vi.fn()} onRequestInsertTemplate={vi.fn()} />)
+
+    expect(menuItemNames()).toEqual([
+      'Turn into',
+      'Text',
+      expect.stringMatching(/^Duplicate/),
+      'Insert template…',
+      'Move to…'
+    ])
+  })
+
+  it('requests an insert anchored below the hovered block without consuming it', async () => {
+    const onRequestInsertTemplate = vi.fn()
+    render(<BlockSideMenuController onRequestInsertTemplate={onRequestInsertTemplate} />)
+
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Insert template…' }))
+
+    expect(onRequestInsertTemplate).toHaveBeenCalledTimes(1)
+    expect(onRequestInsertTemplate).toHaveBeenCalledWith({
+      blockId: 'block-1',
+      placement: 'after'
+    })
+  })
+
+  it('is hidden when no handler is wired', () => {
+    render(<BlockSideMenuController />)
+
+    expect(screen.queryByRole('menuitem', { name: 'Insert template…' })).toBeNull()
+  })
+
+  it('is hidden when no block is hovered', () => {
+    state.block = undefined
+    render(<BlockSideMenuController onRequestInsertTemplate={vi.fn()} />)
+
+    expect(screen.queryByRole('menuitem', { name: 'Insert template…' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/block-side-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/block-side-menu.tsx
@@ -31,10 +31,11 @@ import { SideMenuExtension } from '@blocknote/core/extensions'
 import { TextSelection } from 'prosemirror-state'
 import type { Node as ProseMirrorNode } from 'prosemirror-model'
 import type { BlockNoteEditor } from '@blocknote/core'
-import { ArrowRight, Copy, MessageCircle, Palette, Trash2, Type } from '@/lib/icons'
+import { ArrowRight, Copy, LayoutTemplate, MessageCircle, Palette, Trash2, Type } from '@/lib/icons'
 import { useT } from '@memry/i18n/renderer'
 import { isMac } from '@/lib/shortcut-registry'
 import { getEditorSelectionFromState, getProseMirrorState } from './review-formatting-toolbar'
+import type { TemplateAnchor } from './insert-template'
 import type { ReviewSelection } from './types'
 
 type AnyBlock = { id: string; type: string; props?: Record<string, unknown>; content?: unknown }
@@ -244,6 +245,25 @@ function MoveToItem({ onRequestMove }: { onRequestMove?: (blockId: string) => vo
   )
 }
 
+function InsertTemplateItem({
+  onRequestInsertTemplate
+}: {
+  onRequestInsertTemplate?: (anchor: TemplateAnchor) => void
+}) {
+  const { t } = useT('notes')
+  const block = useCurrentBlock()
+
+  if (!block || !onRequestInsertTemplate) return null
+
+  return (
+    <MenuItem
+      icon={<LayoutTemplate size={16} />}
+      label={t('editor.blockMenu.insertTemplate')}
+      onClick={() => onRequestInsertTemplate({ blockId: block.id, placement: 'after' })}
+    />
+  )
+}
+
 function CommentItem({ onAddComment }: { onAddComment?: (selection: ReviewSelection) => void }) {
   const { t } = useT('notes')
   const editor = useBlockNoteEditor<any, any, any>()
@@ -306,6 +326,7 @@ export interface BlockSideMenuProps {
   onAddComment?: (selection: ReviewSelection) => void
   /** Opens the "move block to another note" picker for the given block. */
   onRequestMove?: (blockId: string) => void
+  onRequestInsertTemplate?: (anchor: TemplateAnchor) => void
 }
 
 interface BlockSideMenuControllerProps extends BlockSideMenuProps {
@@ -322,13 +343,20 @@ interface BlockSideMenuControllerProps extends BlockSideMenuProps {
 export function BlockSideMenuController({
   onAddComment,
   onRequestMove,
+  onRequestInsertTemplate,
   floatingUIOptions
 }: BlockSideMenuControllerProps) {
   const { t } = useT('notes')
 
   const dragHandleMenu = useMemo<FC>(
-    () => () => <MemryDragHandleMenu onAddComment={onAddComment} onRequestMove={onRequestMove} />,
-    [onAddComment, onRequestMove]
+    () => () => (
+      <MemryDragHandleMenu
+        onAddComment={onAddComment}
+        onRequestMove={onRequestMove}
+        onRequestInsertTemplate={onRequestInsertTemplate}
+      />
+    ),
+    [onAddComment, onRequestMove, onRequestInsertTemplate]
   )
 
   const sideMenu = useMemo<FC>(
@@ -343,7 +371,11 @@ export function BlockSideMenuController({
   return <SideMenuController sideMenu={sideMenu} floatingUIOptions={floatingUIOptions} />
 }
 
-function MemryDragHandleMenu({ onAddComment, onRequestMove }: BlockSideMenuProps) {
+function MemryDragHandleMenu({
+  onAddComment,
+  onRequestMove,
+  onRequestInsertTemplate
+}: BlockSideMenuProps) {
   const { t } = useT('notes')
   const Components = useComponentsContext()!
 
@@ -361,6 +393,7 @@ function MemryDragHandleMenu({ onAddComment, onRequestMove }: BlockSideMenuProps
       </BlockColorsItem>
       <Components.Generic.Menu.Divider />
       <DuplicateItem />
+      <InsertTemplateItem onRequestInsertTemplate={onRequestInsertTemplate} />
       <MoveToItem onRequestMove={onRequestMove} />
       <RemoveBlockItem>
         <span className="flex items-center gap-2">

--- a/apps/desktop/src/renderer/src/components/note/content-area/insert-template.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/insert-template.test.ts
@@ -61,7 +61,7 @@ describe('insertTemplateBlocks', () => {
       content: '# {{title}}\n\nAgenda for {{title}}',
       noteTitle: 'Weekly review',
       referenceBlockId: 'ref',
-      consumeEmptyReference: false
+      placement: 'after'
     })
 
     expect(mocks.parseMarkdownPreservingBlanks).toHaveBeenCalledWith(
@@ -80,7 +80,7 @@ describe('insertTemplateBlocks', () => {
       content: '   \n\t\n  ',
       noteTitle: 'Weekly review',
       referenceBlockId: 'ref',
-      consumeEmptyReference: true
+      placement: 'replace-if-empty'
     })
 
     expect(result).toEqual({ ok: false, reason: 'empty' })
@@ -99,7 +99,7 @@ describe('insertTemplateBlocks', () => {
       content: '# Agenda',
       noteTitle: 'Weekly review',
       referenceBlockId: 'ref',
-      consumeEmptyReference: true
+      placement: 'replace-if-empty'
     })
 
     expect(result).toEqual({ ok: false, reason: 'stale-block' })
@@ -116,7 +116,7 @@ describe('insertTemplateBlocks', () => {
       content: '# Agenda',
       noteTitle: 'Weekly review',
       referenceBlockId: 'ref',
-      consumeEmptyReference: true
+      placement: 'replace-if-empty'
     })
 
     expect(replaceBlocks).toHaveBeenCalledWith(
@@ -135,7 +135,7 @@ describe('insertTemplateBlocks', () => {
       content: '# Agenda',
       noteTitle: 'Weekly review',
       referenceBlockId: 'ref',
-      consumeEmptyReference: true
+      placement: 'replace-if-empty'
     })
 
     expect(insertBlocks).toHaveBeenCalledWith(
@@ -161,7 +161,7 @@ describe('insertTemplateBlocks', () => {
       content: '- item',
       noteTitle: 'Weekly review',
       referenceBlockId: 'ref',
-      consumeEmptyReference: false
+      placement: 'after'
     })
 
     const [blocks] = insertBlocks.mock.calls[0]
@@ -181,7 +181,7 @@ describe('insertTemplateBlocks', () => {
       content: '# Agenda\n\nbody',
       noteTitle: 'Weekly review',
       referenceBlockId: 'ref',
-      consumeEmptyReference: false
+      placement: 'after'
     })
 
     expect(setTextCursorPosition).toHaveBeenCalledWith(
@@ -200,7 +200,7 @@ describe('insertTemplateBlocks', () => {
       content: '<!-- nothing -->',
       noteTitle: 'Note',
       referenceBlockId: 'ref',
-      consumeEmptyReference: true
+      placement: 'replace-if-empty'
     })
 
     expect(result).toEqual({ ok: false, reason: 'empty' })

--- a/apps/desktop/src/renderer/src/components/note/content-area/insert-template.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/insert-template.ts
@@ -7,12 +7,19 @@ import { normalizeNoteBlocks } from './normalize-note-blocks'
 
 const log = createLogger('InsertTemplate')
 
+export type TemplatePlacement = 'replace-if-empty' | 'after'
+
+export interface TemplateAnchor {
+  blockId: string
+  placement: TemplatePlacement
+}
+
 export interface InsertTemplateArgs {
   editor: any
   content: string
   noteTitle: string
   referenceBlockId: string
-  consumeEmptyReference: boolean
+  placement: TemplatePlacement
   notePath?: string
 }
 
@@ -32,7 +39,7 @@ export async function insertTemplateBlocks({
   content,
   noteTitle,
   referenceBlockId,
-  consumeEmptyReference,
+  placement,
   notePath
 }: InsertTemplateArgs): Promise<InsertTemplateResult> {
   const markdown = substituteTemplatePlaceholders(content, noteTitle)
@@ -49,7 +56,7 @@ export async function insertTemplateBlocks({
   }
 
   const result =
-    consumeEmptyReference && isEmptyParagraph(reference)
+    placement === 'replace-if-empty' && isEmptyParagraph(reference)
       ? editor.replaceBlocks([reference], blocks)
       : editor.insertBlocks(blocks, reference, 'after')
 

--- a/apps/desktop/tests/e2e/insert-template-block-menu.e2e.ts
+++ b/apps/desktop/tests/e2e/insert-template-block-menu.e2e.ts
@@ -1,0 +1,116 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { createNote, SELECTORS } from './utils/electron-helpers'
+
+async function focusEditor(page: Page): Promise<void> {
+  const editor = page.locator(SELECTORS.noteEditor).first()
+  await editor.waitFor({ state: 'visible', timeout: 10_000 })
+  await editor.click()
+}
+
+async function seedDocument(page: Page, paragraphs: string[]): Promise<void> {
+  await page.evaluate((paragraphs) => {
+    const editor = (window as any).__memryEditor
+    if (!editor) throw new Error('window.__memryEditor not exposed')
+    editor.replaceBlocks(
+      editor.document,
+      paragraphs.map((text) => ({
+        type: 'paragraph',
+        content: text ? [{ type: 'text', text, styles: {} }] : ''
+      }))
+    )
+  }, paragraphs)
+}
+
+async function blockTextsWithoutTrailingBlanks(page: Page): Promise<string[]> {
+  const texts: string[] = await page.evaluate(() => {
+    const editor = (window as any).__memryEditor
+    if (!editor) throw new Error('window.__memryEditor not exposed')
+    return editor.document.map((block: any) =>
+      Array.isArray(block.content) ? block.content.map((part: any) => part.text ?? '').join('') : ''
+    )
+  })
+  while (texts.length > 0 && texts[texts.length - 1] === '') texts.pop()
+  return texts
+}
+
+async function openDragHandleMenu(page: Page, blockIndex: number): Promise<void> {
+  await page.locator('.bn-block-content').nth(blockIndex).hover()
+  const handle = page.locator('[data-test="dragHandle"]').first()
+  await handle.waitFor({ state: 'visible', timeout: 5_000 })
+  await handle.click()
+  await page.locator('[role="menu"]').first().waitFor({ state: 'visible', timeout: 5_000 })
+}
+
+async function createTemplate(page: Page, name: string, content: string): Promise<void> {
+  await page.evaluate(
+    async ({ name, content }) => {
+      const created = await window.api.templates.create({
+        name,
+        description: 'Inserted from the block menu',
+        content
+      })
+      if (!created.success) throw new Error(created.error ?? 'template create failed')
+    },
+    { name, content }
+  )
+}
+
+async function pickTemplate(page: Page, templateName: string): Promise<void> {
+  await page
+    .getByRole('menuitem', { name: /Insert template/ })
+    .first()
+    .click()
+  const search = page.getByPlaceholder('Search templates...')
+  await search.waitFor({ state: 'visible', timeout: 5_000 })
+  await search.fill(templateName)
+  await page
+    .getByRole('button', { name: new RegExp(templateName) })
+    .first()
+    .click()
+  await page.getByRole('button', { name: 'Apply Template' }).click()
+}
+
+test.describe('Insert template from the block side menu E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    await ready(page)
+  })
+
+  test('lands the template below the hovered block and keeps every other block', async ({
+    page
+  }) => {
+    const templateName = uniqueLabel('Block Menu Template')
+    await createTemplate(page, templateName, '## Agenda\n\nDiscuss {{title}}')
+
+    const noteTitle = uniqueLabel('Block Menu Insert')
+    await createNote(page, noteTitle)
+
+    await focusEditor(page)
+    await seedDocument(page, ['First', 'Second', 'Third'])
+
+    await openDragHandleMenu(page, 0)
+    await pickTemplate(page, templateName)
+
+    await expect
+      .poll(() => blockTextsWithoutTrailingBlanks(page))
+      .toEqual(['First', 'Agenda', `Discuss ${noteTitle}`, 'Second', 'Third'])
+  })
+
+  test('keeps an empty hovered block instead of replacing it', async ({ page }) => {
+    const templateName = uniqueLabel('Block Menu Keep Empty')
+    await createTemplate(page, templateName, 'Template line')
+
+    await createNote(page, uniqueLabel('Block Menu Keeps Empty'))
+
+    await focusEditor(page)
+    await seedDocument(page, ['', 'Tail'])
+
+    await openDragHandleMenu(page, 0)
+    await pickTemplate(page, templateName)
+
+    await expect
+      .poll(() => blockTextsWithoutTrailingBlanks(page))
+      .toEqual(['', 'Template line', 'Tail'])
+  })
+})

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -152,7 +152,9 @@ Type `/` anywhere in the editor to insert a block. Filter by typing — `/h2` ju
 
 `/` and **Insert template…** drops a [template](/user-guide/templates)'s body in at the cursor. Choosing the row opens the picker. Type a query instead and matching templates appear as their own rows under **Templates**, so `/meeting` then <kbd>Enter</kbd> inserts Meeting Notes straight away.
 
-Nothing already in the note is touched: the text before and after the cursor stays as it was. See [Inserting a Template at the Cursor](/user-guide/templates#inserting-a-template-at-the-cursor) for how it differs from **Apply Template**.
+The block handle offers the same thing: hover a block, click its <kbd>⋮⋮</kbd> handle, and **Insert template…** puts the template directly below that block.
+
+Nothing already in the note is touched: the text before and after the insertion point stays as it was. See [Inserting a Template at the Cursor](/user-guide/templates#inserting-a-template-at-the-cursor) for how it differs from **Apply Template**.
 
 ## Markdown Shortcuts
 

--- a/apps/docs/src/user-guide/templates.md
+++ b/apps/docs/src/user-guide/templates.md
@@ -116,7 +116,9 @@ Inserting never replaces anything. Everything before and after the cursor stays 
 
 Only the template's **body** is inserted. Its tags and properties are not applied to the note — use **Apply Template** above if you want those.
 
-`{{title}}` resolves to the note's title. The row is hidden while the cursor is inside a table cell.
+There is a second way in, for when you would rather point at a block than move the cursor. Hover any block, click its <kbd>⋮⋮</kbd> drag handle, and pick **Insert template…**. The template lands directly below the block you hovered, and that block is left alone even when it is empty.
+
+`{{title}}` resolves to the note's title. The slash row is hidden while the cursor is inside a table cell.
 
 ## Deleting a Template
 

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -278,6 +278,7 @@
       },
       "colors": "Colors",
       "duplicate": "Duplicate",
+      "insertTemplate": "Insert template…",
       "moveTo": "Move to…",
       "delete": "Delete",
       "comment": "Comment",


### PR DESCRIPTION
## Summary

Stacked on #2171, which added `insertTemplateBlocks` and the slash-menu surface. This adds the second surface.

Hover a block, click its drag handle, and **Insert template…** sits between **Duplicate** and **Move to…**. It opens the same `TemplateSelector` picker, and the template lands directly below the hovered block. Unlike the slash path, the hovered block always survives, even when it is empty: you are pointing at a block, not standing in one.

Two structural notes for the reviewer:

- The picker cannot mount inside the menu. `SideMenuController` unmounts the drag-handle menu the moment a row is clicked, which would take a dialog rendered by the item down with it before the user could choose anything. So `TemplateSelector` stays at `ContentArea`'s top level where `MoveBlockDialog` already lives, and `InsertTemplateItem` is a pure emitter closing over a handler passed through `BlockSideMenuProps`, exactly like `onRequestMove`.
- The two surfaces disagree about what to do with the reference block, so the anchor now names its placement instead of carrying a bare boolean. `TemplateAnchor` is `{ blockId, placement: 'replace-if-empty' | 'after' }`. The slash rows pass `'replace-if-empty'`, this menu passes `'after'`. That replaced `consumeEmptyReference: boolean`, which read as a naked `true` / `false` at four call sites and needed a comment to be legible.

The note title and path cost nothing here: `ContentArea`'s existing `fetchNote()` already memoizes `notesService.get(noteId)` per note, and the shared `insertTemplate` callback already reads it, so the block-menu path inherits it with no new lookup and nothing threaded through the menu.

`attachment-block-menu.tsx` is untouched; that is the right-click context menu on file blocks, a different surface.

## Release note

The block handle menu can now insert a template. Hover any block, open its handle menu, and **Insert template…** drops a template's body in directly below that block.

## Test plan

All run locally from the worktree, on top of `insert-template-slash-menu`.

- `pnpm typecheck` — `Tasks: 19 successful, 19 total`
- `pnpm lint` — `✖ 1 problem (0 errors, 1 warning)`; the warning is `vault-switcher.tsx 96:9 react-you-might-not-need-an-effect/no-event-handler`, pre-existing and outside this diff
- `pnpm --filter @memry/desktop test:renderer` — `Test Files 746 passed (746)`, `Tests 9196 passed | 2 expected fail | 7 skipped (9205)`
- `pnpm --filter @memry/desktop test:main` — `Test Files 586 passed | 3 skipped (589)`, `Tests 8269 passed | 1 expected fail | 6 skipped (8276)`
- `pnpm --filter @memry/desktop i18n:check` — `ok: i18n check passed`
- `pnpm --filter @memry/desktop exec playwright test --config config/playwright.config.ts tests/e2e/insert-template-block-menu.e2e.ts tests/e2e/insert-template-slash-menu.e2e.ts tests/e2e/editor-drag-handle-menu.e2e.ts` — `9 passed (1.8m)`
- `pnpm docs:impact --base insert-template-slash-menu --strict` — `docs impact: docs changed on this branch`
- `pnpm docs:build` — `build complete in 3.35s`
- `git diff --check` — clean

The e2e spec is the real proof, against the built Electron app: it creates a template over the real IPC, hovers a block in a multi-block note, drives the actual drag handle and the actual picker, and asserts the template landed immediately below the hovered block with every other block intact and in order. A second case asserts an empty hovered block is kept rather than replaced, which is the behavioural difference from the slash surface. The existing `editor-drag-handle-menu.e2e.ts` suite was rerun in the same command because this changes that menu.

`block-side-menu.test.tsx` is new; there was no test file for that surface. It covers the item rendering, the click emitting `{ blockId, placement: 'after' }`, and the hide case.

Known coverage gap, named rather than hidden: the composition from picker to `insertTemplateBlocks` on the block-menu path is proven by the e2e only, not by a renderer test. Reaching it in `ContentArea.test.tsx` would mean changing its `SideMenu` mock to invoke `dragHandleMenu()`, which pulls every other menu item into that suite's fixture.
