### PR TITLE
fix(agent): bind MCP vault writes to a running turn

### DIFF
--- a/apps/desktop/src/main/agent/__tests__/turn-grants.test.ts
+++ b/apps/desktop/src/main/agent/__tests__/turn-grants.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  mintTurnWriteGrant,
+  resolveTurnWriteGrant,
+  revokeAllTurnWriteGrants,
+  revokeTurnWriteGrantsFor
+} from '../turn-grants'
+
+describe('turn write grants', () => {
+  beforeEach(() => {
+    revokeAllTurnWriteGrants()
+  })
+
+  it('mints an unguessable capability that resolves to its conversation', () => {
+    const grant = mintTurnWriteGrant('conversation-1')
+    expect(grant).toMatch(/^[0-9a-f]{64}$/)
+    expect(resolveTurnWriteGrant(grant)).toBe('conversation-1')
+  })
+
+  it('resolves nothing for a conversation id, which is what a client could guess', () => {
+    mintTurnWriteGrant('conversation-1')
+    expect(resolveTurnWriteGrant('conversation-1')).toBeNull()
+    expect(resolveTurnWriteGrant(null)).toBeNull()
+    expect(resolveTurnWriteGrant('')).toBeNull()
+  })
+
+  it('mints a fresh capability per turn and drops the previous one', () => {
+    const first = mintTurnWriteGrant('conversation-1')
+    const second = mintTurnWriteGrant('conversation-1')
+    expect(second).not.toBe(first)
+    expect(resolveTurnWriteGrant(first)).toBeNull()
+    expect(resolveTurnWriteGrant(second)).toBe('conversation-1')
+  })
+
+  it('revokes only the conversation whose turn ended', () => {
+    const one = mintTurnWriteGrant('conversation-1')
+    const two = mintTurnWriteGrant('conversation-2')
+
+    revokeTurnWriteGrantsFor('conversation-1')
+
+    expect(resolveTurnWriteGrant(one)).toBeNull()
+    expect(resolveTurnWriteGrant(two)).toBe('conversation-2')
+  })
+
+  it('revokes everything when the vault closes', () => {
+    const grant = mintTurnWriteGrant('conversation-1')
+    revokeAllTurnWriteGrants()
+    expect(resolveTurnWriteGrant(grant)).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/agent/backends/__tests__/claude-cli-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/claude-cli-backend.test.ts
@@ -16,6 +16,8 @@ vi.mock('../../cli/claude-binary', () => ({
 }))
 
 import { ClaudeCliBackend } from '../claude-cli-backend'
+import type { TurnWriteGrant } from '../../turn-grants'
+const TEST_GRANT = 'turn-grant-1' as TurnWriteGrant
 
 describe('ClaudeCliBackend', () => {
   it('spawns Claude turns and parses JSONL backend events', async () => {
@@ -49,6 +51,7 @@ describe('ClaudeCliBackend', () => {
     const run = await backend.runTurn({
       prompt: 'User: create a task',
       conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       options: { backend: 'claude_cli', claudeEffort: 'high', model: 'sonnet' }
     })
@@ -58,7 +61,7 @@ describe('ClaudeCliBackend', () => {
 
     expect(spawn).toHaveBeenCalledWith({
       prompt: 'User: create a task',
-      conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       effort: 'high',
       model: 'sonnet',

--- a/apps/desktop/src/main/agent/backends/__tests__/codex-cli-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/codex-cli-backend.test.ts
@@ -15,6 +15,8 @@ vi.mock('../../cli/codex-binary', () => ({
 }))
 
 import { CodexCliBackend } from '../codex-cli-backend'
+import type { TurnWriteGrant } from '../../turn-grants'
+const TEST_GRANT = 'turn-grant-1' as TurnWriteGrant
 
 describe('CodexCliBackend', () => {
   it('spawns Codex turns and parses JSONL backend events', async () => {
@@ -26,6 +28,7 @@ describe('CodexCliBackend', () => {
     const run = await backend.runTurn({
       prompt: 'User: ping',
       conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       options: { backend: 'codex_cli', reasoningEffort: 'high', model: 'gpt-5.5' }
     })
@@ -35,7 +38,7 @@ describe('CodexCliBackend', () => {
 
     expect(spawn).toHaveBeenCalledWith({
       prompt: 'User: ping',
-      conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       reasoningEffort: 'high',
       model: 'gpt-5.5',

--- a/apps/desktop/src/main/agent/backends/__tests__/local-openai-compatible-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/local-openai-compatible-backend.test.ts
@@ -24,6 +24,8 @@ vi.mock('ai', () => ({
 }))
 
 import { LocalOpenAICompatibleBackend } from '../local-openai-compatible-backend'
+import type { TurnWriteGrant } from '../../turn-grants'
+const TEST_GRANT = 'turn-grant-1' as TurnWriteGrant
 
 describe('LocalOpenAICompatibleBackend', () => {
   beforeEach(() => {
@@ -82,6 +84,7 @@ describe('LocalOpenAICompatibleBackend', () => {
 
     const run = await backend.runTurn({
       conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       prompt: 'User: create a task',
       options: { backend: 'local_openai_compatible', model: 'llama3.2', toolsEnabled: true }
@@ -157,6 +160,7 @@ describe('LocalOpenAICompatibleBackend', () => {
 
     await backend.runTurn({
       conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       prompt: 'User: hello',
       options: { backend: 'local_openai_compatible', model: 'llama3.2', toolsEnabled: false }
@@ -385,6 +389,7 @@ describe('LocalOpenAICompatibleBackend', () => {
 
     await backend.runTurn({
       conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       prompt: 'User: create a task',
       options: { backend: 'local_openai_compatible', model: 'llama3.2', toolsEnabled: true }
@@ -420,6 +425,7 @@ describe('LocalOpenAICompatibleBackend', () => {
     await backend.runTurn({
       prompt: 'hi',
       conversationId: 'c1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       options: { backend: 'local_openai_compatible' }
     })
@@ -456,6 +462,7 @@ describe('LocalOpenAICompatibleBackend', () => {
     async function turn(backend: LocalOpenAICompatibleBackend): Promise<void> {
       await backend.runTurn({
         conversationId: 'conversation-1',
+        writeGrant: TEST_GRANT,
         windowId: 'window-1',
         prompt: 'User: hello',
         options: { backend: 'local_openai_compatible', model: 'llama3.2', toolsEnabled: true }
@@ -629,6 +636,7 @@ describe('LocalOpenAICompatibleBackend', () => {
     await backend.runTurn({
       prompt: 'hi',
       conversationId: 'c1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       options: { backend: 'local_openai_compatible' }
     })

--- a/apps/desktop/src/main/agent/backends/__tests__/tool-bridge.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/tool-bridge.test.ts
@@ -34,6 +34,8 @@ vi.mock('../../mcp/lifecycle', () => ({
 }))
 
 import { AgentToolBridge, createAiSdkToolSet } from '../tool-bridge'
+import type { TurnWriteGrant } from '../../turn-grants'
+const TEST_GRANT = 'turn-grant-1' as TurnWriteGrant
 
 describe('AgentToolBridge', () => {
   beforeEach(() => {
@@ -52,7 +54,7 @@ describe('AgentToolBridge', () => {
 
     await expect(
       bridge.execute({
-        conversationId: 'conversation-1',
+        writeGrant: TEST_GRANT,
         windowId: 'window-1',
         name: 'vault_create_task',
         args: { title: 'Ship local backend' }
@@ -60,7 +62,7 @@ describe('AgentToolBridge', () => {
     ).resolves.toEqual({ ok: true, data: { id: 'task-1' } })
 
     expect(callTool).toHaveBeenCalledWith({
-      conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       name: 'vault_create_task',
       args: { title: 'Ship local backend' }
@@ -73,7 +75,7 @@ describe('AgentToolBridge', () => {
     })
 
     const tools = createAiSdkToolSet(bridge, {
-      conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1'
     })
 
@@ -82,7 +84,7 @@ describe('AgentToolBridge', () => {
     expect(tools.vault_create_task.inputSchema).toBeDefined()
   })
 
-  it('calls the running Vault MCP server with auth and conversation context', async () => {
+  it('calls the running Vault MCP server with auth and the turn write capability', async () => {
     mocks.clientCallTool.mockResolvedValueOnce({
       isError: false,
       structuredContent: { id: 'task-1' }
@@ -91,7 +93,7 @@ describe('AgentToolBridge', () => {
 
     await expect(
       bridge.execute({
-        conversationId: 'conversation-1',
+        writeGrant: TEST_GRANT,
         windowId: 'window-1',
         name: 'vault_create_task',
         args: { title: 'Ship local backend' }
@@ -104,7 +106,7 @@ describe('AgentToolBridge', () => {
         requestInit: {
           headers: {
             Authorization: 'Bearer agent-token',
-            'X-Memry-Conversation': 'conversation-1',
+            'X-Memry-Turn': TEST_GRANT,
             'X-Memry-Window': 'window-1'
           }
         }
@@ -128,7 +130,7 @@ describe('AgentToolBridge', () => {
 
     await expect(
       bridge.execute({
-        conversationId: 'conversation-1',
+        writeGrant: TEST_GRANT,
         windowId: 'window-1',
         name: 'vault_create_task',
         args: { title: 'Ship local backend' }
@@ -150,7 +152,7 @@ describe('AgentToolBridge', () => {
 
     await expect(
       bridge.execute({
-        conversationId: 'conversation-1',
+        writeGrant: TEST_GRANT,
         windowId: 'window-1',
         name: 'vault_create_task',
         args: 'not an object'
@@ -177,7 +179,7 @@ describe('AgentToolBridge', () => {
 
     await expect(
       bridge.execute({
-        conversationId: 'conversation-1',
+        writeGrant: TEST_GRANT,
         windowId: 'window-1',
         name: 'vault_create_task',
         args: { title: 'Ship local backend' }
@@ -196,7 +198,7 @@ describe('AgentToolBridge', () => {
 
     await expect(
       bridge.execute({
-        conversationId: 'conversation-1',
+        writeGrant: TEST_GRANT,
         windowId: 'window-1',
         name: 'vault_create_task',
         args: { title: 'Ship local backend' }

--- a/apps/desktop/src/main/agent/backends/claude-cli-backend.ts
+++ b/apps/desktop/src/main/agent/backends/claude-cli-backend.ts
@@ -3,9 +3,11 @@ import { DEFAULT_CLAUDE_EFFORT } from '@memry/contracts/ipc-agent'
 import { detectClaudeBinary } from '../cli/claude-binary'
 import { createStreamParser } from '../cli/stream-parser'
 import type { BackendEvent } from '../cli/types'
+import type { TurnWriteGrant } from '../turn-grants'
 import type {
   AgentBackend,
   AgentBackendRunInput,
+  AgentBackendTurnInput,
   BackendRunHandle,
   ClaudeCliSpawnInput,
   RawSubprocessHandle
@@ -18,7 +20,7 @@ export class ClaudeCliBackend implements AgentBackend {
     private readonly deps: { spawn: (input: ClaudeCliSpawnInput) => Promise<RawSubprocessHandle> }
   ) {}
 
-  async runTurn(input: AgentBackendRunInput): Promise<BackendRunHandle> {
+  async runTurn(input: AgentBackendTurnInput): Promise<BackendRunHandle> {
     return this.run(input, 'turn')
   }
 
@@ -42,13 +44,16 @@ export class ClaudeCliBackend implements AgentBackend {
     }
   }
 
-  private async run(input: AgentBackendRunInput, purpose: 'turn' | 'summary' | 'title') {
+  private async run(
+    input: AgentBackendRunInput & { writeGrant?: TurnWriteGrant },
+    purpose: 'turn' | 'summary' | 'title'
+  ) {
     const effort =
       input.options.backend === 'claude_cli' ? input.options.claudeEffort : DEFAULT_CLAUDE_EFFORT
     const model = input.options.backend === 'claude_cli' ? input.options.model : undefined
     const subprocess = await this.deps.spawn({
       prompt: input.prompt,
-      conversationId: input.conversationId,
+      ...(input.writeGrant ? { writeGrant: input.writeGrant } : {}),
       windowId: input.windowId,
       effort,
       model,

--- a/apps/desktop/src/main/agent/backends/codex-cli-backend.ts
+++ b/apps/desktop/src/main/agent/backends/codex-cli-backend.ts
@@ -1,9 +1,11 @@
 import { detectCodexBinary } from '../cli/codex-binary'
 import { createCodexStreamParser } from '../cli/codex-stream-parser'
 import type { BackendEvent } from '../cli/types'
+import type { TurnWriteGrant } from '../turn-grants'
 import type {
   AgentBackend,
   AgentBackendRunInput,
+  AgentBackendTurnInput,
   BackendRunHandle,
   CodexCliSpawnInput,
   RawSubprocessHandle
@@ -16,7 +18,7 @@ export class CodexCliBackend implements AgentBackend {
     private readonly deps: { spawn: (input: CodexCliSpawnInput) => Promise<RawSubprocessHandle> }
   ) {}
 
-  async runTurn(input: AgentBackendRunInput): Promise<BackendRunHandle> {
+  async runTurn(input: AgentBackendTurnInput): Promise<BackendRunHandle> {
     return this.run(input, 'turn')
   }
 
@@ -40,13 +42,16 @@ export class CodexCliBackend implements AgentBackend {
     }
   }
 
-  private async run(input: AgentBackendRunInput, purpose: 'turn' | 'summary' | 'title') {
+  private async run(
+    input: AgentBackendRunInput & { writeGrant?: TurnWriteGrant },
+    purpose: 'turn' | 'summary' | 'title'
+  ) {
     const reasoningEffort =
       input.options.backend === 'codex_cli' ? input.options.reasoningEffort : 'medium'
     const model = input.options.backend === 'codex_cli' ? input.options.model : undefined
     const subprocess = await this.deps.spawn({
       prompt: input.prompt,
-      conversationId: input.conversationId,
+      ...(input.writeGrant ? { writeGrant: input.writeGrant } : {}),
       windowId: input.windowId,
       reasoningEffort,
       model,

--- a/apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts
+++ b/apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts
@@ -9,7 +9,13 @@ import { stepCountIs, streamText } from 'ai'
 
 import type { BackendEvent } from '../cli/types'
 import { AgentToolBridge, createAiSdkToolSet } from './tool-bridge'
-import type { AgentBackend, AgentBackendRunInput, BackendRunHandle } from './types'
+import type { TurnWriteGrant } from '../turn-grants'
+import type {
+  AgentBackend,
+  AgentBackendRunInput,
+  AgentBackendTurnInput,
+  BackendRunHandle
+} from './types'
 
 let nextLocalRunPid = -1
 
@@ -62,7 +68,7 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
     }
   ) {}
 
-  async runTurn(input: AgentBackendRunInput): Promise<BackendRunHandle> {
+  async runTurn(input: AgentBackendTurnInput): Promise<BackendRunHandle> {
     return this.run(input, true)
   }
 
@@ -134,7 +140,10 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
     return result
   }
 
-  private async run(input: AgentBackendRunInput, allowTools: boolean): Promise<BackendRunHandle> {
+  private async run(
+    input: AgentBackendRunInput & { writeGrant?: TurnWriteGrant },
+    allowTools: boolean
+  ): Promise<BackendRunHandle> {
     const settings = await this.deps.getSettings()
     const apiKey = await this.deps.getApiKey()
     const options = input.options.backend === this.id ? input.options : null
@@ -162,10 +171,10 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
       ...(isOllama
         ? { providerOptions: { ollama: { options: { num_ctx: OLLAMA_NUM_CTX } } } }
         : {}),
-      ...(toolsEnabled
+      ...(toolsEnabled && input.writeGrant
         ? {
             tools: createAiSdkToolSet(this.deps.toolBridge, {
-              conversationId: input.conversationId,
+              writeGrant: input.writeGrant,
               windowId: input.windowId
             })
           }

--- a/apps/desktop/src/main/agent/backends/tool-bridge.ts
+++ b/apps/desktop/src/main/agent/backends/tool-bridge.ts
@@ -5,11 +5,12 @@ import type { ToolSet } from 'ai'
 import { createLogger } from '../../lib/logger'
 import { trackMainError } from '../../telemetry/diagnostics'
 import { ALL_TOOL_NAMES, TOOL_SCHEMAS, type ToolName } from '../mcp/tools/schemas'
+import type { TurnWriteGrant } from '../turn-grants'
 
 const logger = createLogger('AgentToolBridge')
 
 export interface AgentToolCallInput {
-  conversationId: string
+  writeGrant: TurnWriteGrant
   windowId: string
   name: ToolName
   args: unknown
@@ -31,7 +32,7 @@ export class AgentToolBridge {
 
 export function createAiSdkToolSet(
   bridge: AgentToolBridge,
-  ctx: { conversationId: string; windowId: string }
+  ctx: { writeGrant: TurnWriteGrant; windowId: string }
 ): ToolSet {
   const tools: ToolSet = {}
   for (const name of ALL_TOOL_NAMES) {
@@ -41,7 +42,7 @@ export function createAiSdkToolSet(
       inputSchema: schema.input,
       execute: async (args: unknown) =>
         bridge.execute({
-          conversationId: ctx.conversationId,
+          writeGrant: ctx.writeGrant,
           windowId: ctx.windowId,
           name,
           args
@@ -66,7 +67,7 @@ async function callVaultMcpTool(input: AgentToolCallInput): Promise<AgentToolCal
     requestInit: {
       headers: {
         Authorization: `Bearer ${status.token}`,
-        'X-Memry-Conversation': input.conversationId,
+        'X-Memry-Turn': input.writeGrant,
         'X-Memry-Window': input.windowId
       }
     }

--- a/apps/desktop/src/main/agent/backends/types.ts
+++ b/apps/desktop/src/main/agent/backends/types.ts
@@ -9,6 +9,7 @@ import type {
 } from '@memry/contracts/ipc-agent'
 
 import type { BackendEvent } from '../cli/types'
+import type { TurnWriteGrant } from '../turn-grants'
 
 export interface BackendRunHandle {
   events: AsyncIterable<BackendEvent>
@@ -28,9 +29,18 @@ export interface AgentBackendRunInput {
   purpose?: 'turn' | 'summary' | 'title'
 }
 
+/**
+ * A real turn, as opposed to the title and summary runs that share the shape.
+ * Only a turn may write to the vault, so only a turn carries the capability —
+ * the compiler, not a runtime check, is what keeps the two apart.
+ */
+export interface AgentBackendTurnInput extends AgentBackendRunInput {
+  writeGrant: TurnWriteGrant
+}
+
 export interface AgentBackend {
   id: AgentBackendId
-  runTurn(input: AgentBackendRunInput): Promise<BackendRunHandle>
+  runTurn(input: AgentBackendTurnInput): Promise<BackendRunHandle>
   generateTitle(input: AgentBackendRunInput): Promise<BackendRunHandle>
   summarize(input: AgentBackendRunInput): Promise<BackendRunHandle>
   getStatus(): Promise<AgentBackendStatus>
@@ -39,7 +49,7 @@ export interface AgentBackend {
 
 export interface ClaudeCliSpawnInput {
   prompt: string
-  conversationId: string
+  writeGrant?: TurnWriteGrant
   windowId: string
   effort: ClaudeEffort
   model?: string
@@ -49,7 +59,7 @@ export interface ClaudeCliSpawnInput {
 
 export interface CodexCliSpawnInput {
   prompt: string
-  conversationId: string
+  writeGrant?: TurnWriteGrant
   windowId: string
   reasoningEffort: CodexReasoningEffort
   model?: string

--- a/apps/desktop/src/main/agent/bootstrap.test.ts
+++ b/apps/desktop/src/main/agent/bootstrap.test.ts
@@ -142,6 +142,8 @@ vi.mock('./runtime/runtime', () => ({
 }))
 
 import { startAgent } from './bootstrap'
+import type { TurnWriteGrant } from './turn-grants'
+const TEST_GRANT = 'turn-grant-1' as TurnWriteGrant
 
 describe('startAgent', () => {
   beforeEach(() => {
@@ -212,6 +214,7 @@ describe('startAgent', () => {
     await deps.backends.get('claude_cli').runTurn({
       prompt: 'hello',
       conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       options: { backend: 'claude_cli', claudeEffort: 'low', model: 'sonnet' }
     })
@@ -222,7 +225,7 @@ describe('startAgent', () => {
         mcp: {
           serverUrl: 'http://127.0.0.1:54321',
           authorizationValue: 'local-auth-value',
-          conversationId: 'conversation-1',
+          writeGrant: TEST_GRANT,
           windowId: 'window-1',
           allowedTools: expect.stringContaining('mcp__memry__')
         },
@@ -240,6 +243,7 @@ describe('startAgent', () => {
     await deps.backends.get('claude_cli').runTurn({
       prompt: 'hello',
       conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       options: { backend: 'claude_cli', claudeEffort: 'low' }
     })
@@ -256,7 +260,7 @@ describe('startAgent', () => {
         mcp: expect.objectContaining({
           serverUrl: 'http://127.0.0.1:54321',
           authorizationValue: 'local-auth-value',
-          conversationId: 'conversation-1',
+          writeGrant: TEST_GRANT,
           windowId: 'window-1'
         })
       })
@@ -274,6 +278,7 @@ describe('startAgent', () => {
     await deps.backends.get('codex_cli').runTurn({
       prompt: 'hello',
       conversationId: 'conversation-1',
+      writeGrant: TEST_GRANT,
       windowId: 'window-1',
       options: { backend: 'codex_cli', reasoningEffort: 'high', model: 'gpt-5.5' }
     })
@@ -294,7 +299,7 @@ describe('startAgent', () => {
         mcp: {
           serverUrl: 'http://127.0.0.1:54321',
           authorizationValue: 'local-auth-value',
-          conversationId: 'conversation-1',
+          writeGrant: TEST_GRANT,
           windowId: 'window-1'
         }
       })

--- a/apps/desktop/src/main/agent/bootstrap.ts
+++ b/apps/desktop/src/main/agent/bootstrap.ts
@@ -113,7 +113,7 @@ export async function startAgent(): Promise<AgentHandle> {
 
   const spawnClaudeAdapter = async ({
     prompt,
-    conversationId,
+    writeGrant,
     windowId,
     effort,
     model,
@@ -132,12 +132,12 @@ export async function startAgent(): Promise<AgentHandle> {
 
     const sub = await spawnClaudeTurn({
       binaryPath: 'claude',
-      ...(status?.url && status['token']
+      ...(status?.url && status['token'] && writeGrant
         ? {
             mcp: {
               serverUrl: status.url,
               authorizationValue: status['token'],
-              conversationId,
+              writeGrant,
               windowId,
               allowedTools: ALLOWED_AGENT_TOOLS
             }
@@ -170,7 +170,7 @@ export async function startAgent(): Promise<AgentHandle> {
 
   const spawnCodexAdapter = async ({
     prompt,
-    conversationId,
+    writeGrant,
     windowId,
     reasoningEffort,
     model,
@@ -193,12 +193,12 @@ export async function startAgent(): Promise<AgentHandle> {
       reasoningEffort,
       model,
       ...(permissions ? { permissions } : {}),
-      ...(status?.url && status['token']
+      ...(status?.url && status['token'] && writeGrant
         ? {
             mcp: {
               serverUrl: status.url,
               authorizationValue: status['token'],
-              conversationId,
+              writeGrant,
               windowId
             }
           }

--- a/apps/desktop/src/main/agent/cli/__tests__/codex-spawn.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/codex-spawn.test.ts
@@ -23,7 +23,7 @@ describe('spawnCodexTurn', () => {
       mcp: {
         serverUrl: 'http://127.0.0.1:54321',
         authorizationValue: 'test-token',
-        conversationId: 'conversation-1',
+        writeGrant: 'turn-grant-1',
         windowId: 'window-1'
       }
     })
@@ -44,7 +44,7 @@ describe('spawnCodexTurn', () => {
     expect(args).toContain('mcp_servers.memry.url="http://127.0.0.1:54321/mcp"')
     expect(args).toContain('mcp_servers.memry.bearer_token_env_var="MEMRY_AGENT_TOKEN"')
     expect(args).toContain(
-      'mcp_servers.memry.env_http_headers={"X-Memry-Conversation"="MEMRY_AGENT_CONVERSATION","X-Memry-Window"="MEMRY_AGENT_WINDOW"}'
+      'mcp_servers.memry.env_http_headers={"X-Memry-Turn"="MEMRY_AGENT_TURN","X-Memry-Window"="MEMRY_AGENT_WINDOW"}'
     )
     expect(args).toContain('mcp_servers.memry.default_tools_approval_mode="approve"')
 
@@ -56,7 +56,7 @@ describe('spawnCodexTurn', () => {
     expect(options.cwd).toBe('/tmp/memry-codex-test')
     expect(options.stdio).toEqual(['ignore', 'pipe', 'pipe'])
     expect(options.env.MEMRY_AGENT_TOKEN).toBe('test-token')
-    expect(options.env.MEMRY_AGENT_CONVERSATION).toBe('conversation-1')
+    expect(options.env.MEMRY_AGENT_TURN).toBe('turn-grant-1')
     expect(options.env.MEMRY_AGENT_WINDOW).toBe('window-1')
   })
 
@@ -143,7 +143,7 @@ describe('spawnCodexTurn', () => {
       env: NodeJS.ProcessEnv
     }
     expect(options.env.MEMRY_AGENT_TOKEN).toBeUndefined()
-    expect(options.env.MEMRY_AGENT_CONVERSATION).toBeUndefined()
+    expect(options.env.MEMRY_AGENT_TURN).toBeUndefined()
     expect(options.env.MEMRY_AGENT_WINDOW).toBeUndefined()
   })
 })

--- a/apps/desktop/src/main/agent/cli/__tests__/spawn-failure.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/spawn-failure.test.ts
@@ -92,7 +92,7 @@ describe('CLI spawn failure', () => {
           mcp: {
             serverUrl: 'http://127.0.0.1:54321',
             authorizationValue: 'secret-bearer-token',
-            conversationId: 'conversation-1',
+            writeGrant: 'turn-grant-1',
             windowId: 'window-1',
             allowedTools: 'mcp__memry__vault_read_note'
           },

--- a/apps/desktop/src/main/agent/cli/__tests__/spawn.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/spawn.test.ts
@@ -18,7 +18,7 @@ describe('spawnClaudeTurn', () => {
     vi.clearAllMocks()
   })
 
-  it('writes mcp-config.json with bearer + conversation/window headers', async () => {
+  it('writes mcp-config.json with bearer + turn-capability/window headers', async () => {
     const fakeProc = makeFakeProc()
     vi.mocked(spawn).mockReturnValue(fakeProc)
 
@@ -27,7 +27,7 @@ describe('spawnClaudeTurn', () => {
       mcp: {
         serverUrl: 'http://127.0.0.1:54321',
         authorizationValue: 'test-auth-value',
-        conversationId: 'conv-1',
+        writeGrant: 'turn-grant-1',
         windowId: 'win-1',
         allowedTools: 'mcp__memry__vault_read_note'
       },
@@ -39,7 +39,7 @@ describe('spawnClaudeTurn', () => {
     const written = JSON.parse(vi.mocked(writeFile).mock.calls[0][1] as string)
     expect(written.mcpServers.memry.url).toBe('http://127.0.0.1:54321/mcp')
     expect(written.mcpServers.memry.headers.Authorization).toBe('Bearer test-auth-value')
-    expect(written.mcpServers.memry.headers['X-Memry-Conversation']).toBe('conv-1')
+    expect(written.mcpServers.memry.headers['X-Memry-Turn']).toBe('turn-grant-1')
     expect(written.mcpServers.memry.headers['X-Memry-Window']).toBe('win-1')
   })
 
@@ -52,7 +52,7 @@ describe('spawnClaudeTurn', () => {
       mcp: {
         serverUrl: 'http://127.0.0.1:54321',
         authorizationValue: 'test-auth-value',
-        conversationId: 'c',
+        writeGrant: 'turn-grant-1',
         windowId: 'w',
         allowedTools: 'mcp__memry__vault_read_note'
       },
@@ -89,7 +89,7 @@ describe('spawnClaudeTurn', () => {
       mcp: {
         serverUrl: 'http://127.0.0.1:54321',
         authorizationValue: 'test-auth-value',
-        conversationId: 'c',
+        writeGrant: 'turn-grant-1',
         windowId: 'w',
         allowedTools: 'mcp__memry__vault_read_note'
       },
@@ -115,7 +115,7 @@ describe('spawnClaudeTurn', () => {
       mcp: {
         serverUrl: 'http://127.0.0.1:54321',
         authorizationValue: 'test-auth-value',
-        conversationId: 'c',
+        writeGrant: 'turn-grant-1',
         windowId: 'w',
         allowedTools: 'mcp__memry__vault_read_note'
       },
@@ -142,7 +142,7 @@ describe('spawnClaudeTurn', () => {
       mcp: {
         serverUrl: 'http://127.0.0.1:54321',
         authorizationValue: 'test-auth-value',
-        conversationId: 'c',
+        writeGrant: 'turn-grant-1',
         windowId: 'w',
         allowedTools: 'a'
       },
@@ -165,7 +165,7 @@ describe('spawnClaudeTurn', () => {
       mcp: {
         serverUrl: 'http://127.0.0.1:54321',
         authorizationValue: 'test-auth-value',
-        conversationId: 'c',
+        writeGrant: 'turn-grant-1',
         windowId: 'w',
         allowedTools: 'a'
       },

--- a/apps/desktop/src/main/agent/cli/codex-spawn.ts
+++ b/apps/desktop/src/main/agent/cli/codex-spawn.ts
@@ -23,7 +23,7 @@ export interface CodexSpawnOptions {
   mcp?: {
     serverUrl: string
     authorizationValue: string
-    conversationId: string
+    writeGrant: string
     windowId: string
   }
 }
@@ -69,7 +69,7 @@ export async function spawnCodexTurn(opts: CodexSpawnOptions): Promise<CodexSubp
       '-c',
       'mcp_servers.memry.bearer_token_env_var="MEMRY_AGENT_TOKEN"',
       '-c',
-      'mcp_servers.memry.env_http_headers={"X-Memry-Conversation"="MEMRY_AGENT_CONVERSATION","X-Memry-Window"="MEMRY_AGENT_WINDOW"}',
+      'mcp_servers.memry.env_http_headers={"X-Memry-Turn"="MEMRY_AGENT_TURN","X-Memry-Window"="MEMRY_AGENT_WINDOW"}',
       '-c',
       'mcp_servers.memry.default_tools_approval_mode="approve"'
     )
@@ -85,7 +85,7 @@ export async function spawnCodexTurn(opts: CodexSpawnOptions): Promise<CodexSubp
       ...(opts.mcp
         ? {
             MEMRY_AGENT_TOKEN: opts.mcp.authorizationValue,
-            MEMRY_AGENT_CONVERSATION: opts.mcp.conversationId,
+            MEMRY_AGENT_TURN: opts.mcp.writeGrant,
             MEMRY_AGENT_WINDOW: opts.mcp.windowId
           }
         : {})

--- a/apps/desktop/src/main/agent/cli/spawn.ts
+++ b/apps/desktop/src/main/agent/cli/spawn.ts
@@ -20,7 +20,7 @@ export interface SpawnOptions {
   mcp?: {
     serverUrl: string
     authorizationValue: string
-    conversationId: string
+    writeGrant: string
     windowId: string
     allowedTools: string
   }
@@ -72,7 +72,7 @@ export async function spawnClaudeTurn(opts: SpawnOptions): Promise<ClaudeSubproc
           url: `${opts.mcp.serverUrl}/mcp`,
           headers: {
             Authorization: `Bearer ${opts.mcp.authorizationValue}`,
-            'X-Memry-Conversation': opts.mcp.conversationId,
+            'X-Memry-Turn': opts.mcp.writeGrant,
             'X-Memry-Window': opts.mcp.windowId
           }
         }

--- a/apps/desktop/src/main/agent/mcp/__tests__/server.test.ts
+++ b/apps/desktop/src/main/agent/mcp/__tests__/server.test.ts
@@ -371,16 +371,16 @@ describe('Agent MCP server registration reuse', () => {
     }
   })
 
-  it('derives conversation identity per request on a reused server', async () => {
-    const seen: Array<{ conversationId: string | null; windowId: string | null }> = []
+  it('derives the turn write capability per request on a reused server', async () => {
+    const seen: Array<{ writeGrant: string | null; windowId: string | null }> = []
     const handle = await startAgentMcpServer({
       toolRegistrations: [
         buildTool('ctx_probe', async (_input, ctx) => {
-          seen.push({ conversationId: ctx.conversationId, windowId: ctx.windowId })
-          if (!ctx.conversationId) {
+          seen.push({ writeGrant: ctx.writeGrant, windowId: ctx.windowId })
+          if (!ctx.writeGrant) {
             throw new AgentToolError('PERMISSION_DENIED', 'Write tools require a conversation.')
           }
-          return { conversationId: ctx.conversationId }
+          return { writeGrant: ctx.writeGrant }
         })
       ]
     })
@@ -390,9 +390,9 @@ describe('Agent MCP server registration reuse', () => {
         handle,
         'ctx_probe',
         {},
-        { 'x-memry-conversation': 'conv-a', 'x-memry-window': 'win-a' }
+        { 'x-memry-turn': 'grant-a', 'x-memry-window': 'win-a' }
       )
-      expect(await approved.text()).toContain('"conversationId":"conv-a"')
+      expect(await approved.text()).toContain('"writeGrant":"grant-a"')
 
       // Same reused McpServer, different caller: identity must not carry over.
       const denied = await callTool(handle, 'ctx_probe', {})
@@ -402,14 +402,14 @@ describe('Agent MCP server registration reuse', () => {
         handle,
         'ctx_probe',
         {},
-        { 'x-memry-conversation': 'conv-b', 'x-memry-window': 'win-b' }
+        { 'x-memry-turn': 'grant-b', 'x-memry-window': 'win-b' }
       )
-      expect(await other.text()).toContain('"conversationId":"conv-b"')
+      expect(await other.text()).toContain('"writeGrant":"grant-b"')
 
       expect(seen).toEqual([
-        { conversationId: 'conv-a', windowId: 'win-a' },
-        { conversationId: null, windowId: null },
-        { conversationId: 'conv-b', windowId: 'win-b' }
+        { writeGrant: 'grant-a', windowId: 'win-a' },
+        { writeGrant: null, windowId: null },
+        { writeGrant: 'grant-b', windowId: 'win-b' }
       ])
     } finally {
       await handle.stop()
@@ -457,7 +457,7 @@ function buildTool(
   name: string,
   handler: (
     input: unknown,
-    ctx: { conversationId: string | null; windowId: string | null }
+    ctx: { writeGrant: string | null; windowId: string | null }
   ) => Promise<unknown>
 ) {
   return {

--- a/apps/desktop/src/main/agent/mcp/__tests__/session.test.ts
+++ b/apps/desktop/src/main/agent/mcp/__tests__/session.test.ts
@@ -20,18 +20,26 @@ describe('McpSession', () => {
     expect(next).toMatch(/^[0-9a-f]{64}$/)
   })
 
-  it('extracts conversation id from X-Memry-Conversation header', () => {
+  it('extracts the turn write capability from the X-Memry-Turn header', () => {
     const ctx = session.contextFromHeaders({
       authorization: `Bearer ${session.token}`,
-      'x-memry-conversation': 'conv-42',
+      'x-memry-turn': 'turn-grant-42',
       'x-memry-window': 'win-7'
     })
-    expect(ctx).toEqual({ conversationId: 'conv-42', windowId: 'win-7' })
+    expect(ctx).toEqual({ writeGrant: 'turn-grant-42', windowId: 'win-7' })
   })
 
   it('returns null context when the header is absent (external client)', () => {
     const ctx = session.contextFromHeaders({ authorization: `Bearer ${session.token}` })
-    expect(ctx).toEqual({ conversationId: null, windowId: null })
+    expect(ctx).toEqual({ writeGrant: null, windowId: null })
+  })
+
+  it('never reads a write capability out of the old conversation header', () => {
+    const ctx = session.contextFromHeaders({
+      authorization: `Bearer ${session.token}`,
+      'x-memry-conversation': 'conv-42'
+    })
+    expect(ctx.writeGrant).toBeNull()
   })
 
   it('verifies bearer token in constant time', () => {

--- a/apps/desktop/src/main/agent/mcp/server.ts
+++ b/apps/desktop/src/main/agent/mcp/server.ts
@@ -22,7 +22,7 @@ export interface ToolRegistration {
   inputSchema: ZodTypeAny
   handler: (
     input: unknown,
-    ctx: { conversationId: string | null; windowId: string | null }
+    ctx: { writeGrant: string | null; windowId: string | null }
   ) => Promise<unknown>
 }
 

--- a/apps/desktop/src/main/agent/mcp/session.ts
+++ b/apps/desktop/src/main/agent/mcp/session.ts
@@ -1,7 +1,11 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
 
 export interface McpSessionContext {
-  conversationId: string | null
+  /**
+   * Opaque per-turn write capability, as presented by the client. Unverified
+   * here: only the write gate can say whether it names an in-flight turn.
+   */
+  writeGrant: string | null
   windowId: string | null
 }
 
@@ -45,7 +49,7 @@ export function createMcpSession(): McpSession {
     },
     contextFromHeaders(headers) {
       return {
-        conversationId: readHeader(headers, 'x-memry-conversation'),
+        writeGrant: readHeader(headers, 'x-memry-turn'),
         windowId: readHeader(headers, 'x-memry-window')
       }
     }

--- a/apps/desktop/src/main/agent/mcp/tools/__tests__/write-tools.test.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/__tests__/write-tools.test.ts
@@ -114,7 +114,7 @@ describe('Write tools — P1 deny-by-default', () => {
   it('returns PERMISSION_DENIED for vault_create_note when no gate is wired', async () => {
     const t = tools.find((x) => x.name === 'vault_create_note')!
     await expect(
-      t.handler({ title: 't', content_markdown: 'body' }, { conversationId: null, windowId: null })
+      t.handler({ title: 't', content_markdown: 'body' }, { writeGrant: null, windowId: null })
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' })
   })
 
@@ -184,7 +184,7 @@ describe('Write tools — P1 deny-by-default', () => {
     }
     for (const t of tools) {
       await expect(
-        t.handler(valid[t.name], { conversationId: null, windowId: null })
+        t.handler(valid[t.name], { writeGrant: null, windowId: null })
       ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' })
     }
   })
@@ -192,7 +192,7 @@ describe('Write tools — P1 deny-by-default', () => {
   it('still rejects malformed args with VALIDATION before gating', async () => {
     const t = tools.find((x) => x.name === 'vault_create_note')!
     await expect(
-      t.handler({ title: '' }, { conversationId: null, windowId: null })
+      t.handler({ title: '' }, { writeGrant: null, windowId: null })
     ).rejects.toMatchObject({ code: 'VALIDATION' })
   })
 
@@ -202,7 +202,7 @@ describe('Write tools — P1 deny-by-default', () => {
     const t = withGate.find((x) => x.name === 'vault_create_note')!
     const out = await t.handler(
       { title: 'x', content_markdown: 'y' },
-      { conversationId: 'c1', windowId: 'w1' }
+      { writeGrant: 'turn-grant-1', windowId: 'w1' }
     )
     expect(out).toEqual({ id: 'created-note' })
   })
@@ -227,7 +227,7 @@ describe('Write tools — P1 deny-by-default', () => {
     const t = withGate.find((x) => x.name === 'vault_create_note')!
     await t.handler(
       { title: 'orig', content_markdown: 'orig' },
-      { conversationId: 'c1', windowId: 'w1' }
+      { writeGrant: 'turn-grant-1', windowId: 'w1' }
     )
     expect(received).toEqual({ title: 'EDITED', content_markdown: 'EDITED-BODY' })
   })
@@ -297,7 +297,7 @@ describe('Write tools — P1 deny-by-default', () => {
     const withGate = buildWriteTools(localHandles, async () => ({ approved: true }))
     const run = async (name: string, input: unknown) => {
       const tool = withGate.find((x) => x.name === name)!
-      return tool.handler(input, { conversationId: 'c1', windowId: 'w1' })
+      return tool.handler(input, { writeGrant: 'turn-grant-1', windowId: 'w1' })
     }
 
     await expect(run('vault_create_task', { title: 'Task' })).resolves.toEqual({
@@ -540,7 +540,10 @@ describe('Write tools — P1 deny-by-default', () => {
     const withGate = buildWriteTools(handles, gate)
     const t = withGate.find((x) => x.name === 'vault_create_note')!
     await expect(
-      t.handler({ title: 't', content_markdown: 'b' }, { conversationId: 'c1', windowId: 'w1' })
+      t.handler(
+        { title: 't', content_markdown: 'b' },
+        { writeGrant: 'turn-grant-1', windowId: 'w1' }
+      )
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' })
   })
 })

--- a/apps/desktop/src/main/agent/mcp/tools/write-tools.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/write-tools.ts
@@ -8,7 +8,8 @@ import type { AgentMcpDesktopWriteOperation } from '@memry/contracts/agent-mcp-c
 import type { CanvasDrawElement, CanvasElementEdit } from '@memry/contracts/canvas-draw'
 
 export interface GateContext {
-  conversationId: string
+  /** Opaque per-turn capability presented by the caller; the gate verifies it. */
+  writeGrant: string
   windowId: string | null
   toolName: ToolName
   parsedArgs: unknown
@@ -35,10 +36,10 @@ async function gateOrDeny(gate: WriteToolGate | null, ctx: GateContext): Promise
       'Write tools require an active memrynote Agent conversation with an approval gate.'
     )
   }
-  if (!ctx.conversationId) {
+  if (!ctx.writeGrant) {
     throw new AgentToolError(
       'PERMISSION_DENIED',
-      'Write tools require X-Memry-Conversation header.'
+      'Write tools require an in-flight memrynote Agent turn; no X-Memry-Turn capability was presented.'
     )
   }
   const decision = await gate(ctx)
@@ -55,7 +56,7 @@ async function approvedArgs<T>(
   ctx: ToolHandlerContext
 ): Promise<T> {
   return (await gateOrDeny(gate, {
-    conversationId: ctx.conversationId ?? '',
+    writeGrant: ctx.writeGrant ?? '',
     windowId: ctx.windowId,
     toolName,
     parsedArgs
@@ -79,7 +80,7 @@ export function buildWriteTools(
           tags?: string[]
         }>(TOOL_SCHEMAS.vault_create_note.input, input)
         const args = (await gateOrDeny(gate, {
-          conversationId: ctx.conversationId ?? '',
+          writeGrant: ctx.writeGrant ?? '',
           windowId: ctx.windowId,
           toolName: 'vault_create_note',
           parsedArgs: parsed
@@ -389,7 +390,7 @@ export function buildWriteTools(
           input
         )
         const args = (await gateOrDeny(gate, {
-          conversationId: ctx.conversationId ?? '',
+          writeGrant: ctx.writeGrant ?? '',
           windowId: ctx.windowId,
           toolName: 'vault_create_journal_entry',
           parsedArgs: parsed
@@ -430,7 +431,7 @@ export function buildWriteTools(
           input
         )
         const args = (await gateOrDeny(gate, {
-          conversationId: ctx.conversationId ?? '',
+          writeGrant: ctx.writeGrant ?? '',
           windowId: ctx.windowId,
           toolName: 'vault_add_to_inbox',
           parsedArgs: parsed
@@ -531,7 +532,7 @@ export function buildWriteTools(
           content_markdown: string
         }>(TOOL_SCHEMAS.vault_update_note.input, input)
         const args = (await gateOrDeny(gate, {
-          conversationId: ctx.conversationId ?? '',
+          writeGrant: ctx.writeGrant ?? '',
           windowId: ctx.windowId,
           toolName: 'vault_update_note',
           parsedArgs: parsed
@@ -564,7 +565,7 @@ export function buildWriteTools(
           input
         )
         const args = (await gateOrDeny(gate, {
-          conversationId: ctx.conversationId ?? '',
+          writeGrant: ctx.writeGrant ?? '',
           windowId: ctx.windowId,
           toolName: 'vault_add_tag',
           parsedArgs: parsed
@@ -584,7 +585,7 @@ export function buildWriteTools(
           input
         )
         const args = (await gateOrDeny(gate, {
-          conversationId: ctx.conversationId ?? '',
+          writeGrant: ctx.writeGrant ?? '',
           windowId: ctx.windowId,
           toolName: 'vault_remove_tag',
           parsedArgs: parsed
@@ -604,7 +605,7 @@ export function buildWriteTools(
           input
         )
         const args = (await gateOrDeny(gate, {
-          conversationId: ctx.conversationId ?? '',
+          writeGrant: ctx.writeGrant ?? '',
           windowId: ctx.windowId,
           toolName: 'vault_move_to_folder',
           parsedArgs: parsed

--- a/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
@@ -23,6 +23,30 @@ import type { ConversationStore } from '../../storage/conversation-store'
 import { createConversationStore } from '../../storage/conversation-store'
 import type { MessageStore } from '../../storage/message-store'
 import { AgentRuntime } from '../runtime'
+import {
+  mintTurnWriteGrant,
+  revokeAllTurnWriteGrants,
+  type TurnWriteGrant
+} from '../../turn-grants'
+
+/**
+ * One capability per conversation per test. Minting twice for the same
+ * conversation revokes the first, which would invalidate a call still awaiting
+ * its approval.
+ */
+const grants = new Map<string, TurnWriteGrant>()
+function grantFor(conversationId: string): TurnWriteGrant {
+  const existing = grants.get(conversationId)
+  if (existing) return existing
+  const grant = mintTurnWriteGrant(conversationId)
+  grants.set(conversationId, grant)
+  return grant
+}
+
+beforeEach(() => {
+  grants.clear()
+  revokeAllTurnWriteGrants()
+})
 
 /** Drains every queued microtask so an already-settled promise wins a race. */
 function flushMicrotasks(): Promise<void> {
@@ -145,7 +169,7 @@ describe('AgentRuntime approval gate', () => {
     runtime.install()
     const gate = installedGate()
     const write = {
-      conversationId: conversation.id,
+      writeGrant: grantFor(conversation.id),
       toolName: 'vault_create_task',
       parsedArgs: { title: 'Task' }
     }
@@ -161,6 +185,59 @@ describe('AgentRuntime approval gate', () => {
     })
   })
 
+  it('denies a write whose only credential is a real conversation id', async () => {
+    const { runtime, conversations } = createRuntime()
+    conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
+
+    runtime.install()
+
+    await expect(
+      installedGate()({
+        writeGrant: 'conversation-1',
+        toolName: 'vault_delete_note',
+        parsedArgs: { id: 'note-1' }
+      })
+    ).resolves.toEqual({
+      approved: false,
+      reason:
+        'Vault writes are only available to a tool call inside a running memrynote Agent turn.'
+    })
+    expect(conversations.getById).not.toHaveBeenCalled()
+  })
+
+  it('denies a write presenting a capability from a turn that already ended', async () => {
+    const { runtime, conversations } = createRuntime()
+    conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
+
+    runtime.install()
+    const gate = installedGate()
+    const grant = grantFor('conversation-1')
+    await expect(
+      gate({ writeGrant: grant, toolName: 'vault_create_task', parsedArgs: { title: 'T' } })
+    ).resolves.toEqual({ approved: true })
+
+    runtime.releaseTurnLock('conversation-1')
+
+    await expect(
+      gate({ writeGrant: grant, toolName: 'vault_create_task', parsedArgs: { title: 'T' } })
+    ).resolves.toMatchObject({ approved: false })
+  })
+
+  it('revokes every live capability at shutdown', async () => {
+    const { runtime, conversations } = createRuntime()
+    conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
+
+    runtime.install()
+    const gate = installedGate()
+    const grant = grantFor('conversation-1')
+
+    await runtime.killAll()
+
+    await expect(
+      gate({ writeGrant: grant, toolName: 'vault_create_task', parsedArgs: { title: 'T' } })
+    ).resolves.toMatchObject({ approved: false })
+  })
+
   it('rejects writes for unknown conversations', async () => {
     const { runtime, conversations } = createRuntime()
     conversations.getById.mockReturnValue(null)
@@ -169,7 +246,7 @@ describe('AgentRuntime approval gate', () => {
 
     await expect(
       installedGate()({
-        conversationId: 'missing',
+        writeGrant: grantFor('missing'),
         toolName: 'vault_create_task',
         parsedArgs: { title: 'Task' }
       })
@@ -185,7 +262,7 @@ describe('AgentRuntime approval gate', () => {
 
     await expect(
       gate({
-        conversationId: 'conversation-1',
+        writeGrant: grantFor('conversation-1'),
         toolName: 'vault_update_note',
         parsedArgs: { id: 'note-1', content_markdown: 'Draft' }
       })
@@ -205,11 +282,11 @@ describe('AgentRuntime approval gate', () => {
     const gate = installedGate()
 
     await expect(
-      gate({ conversationId: 'conversation-1', toolName: 'vault_read_note', parsedArgs: {} })
+      gate({ writeGrant: grantFor('conversation-1'), toolName: 'vault_read_note', parsedArgs: {} })
     ).resolves.toEqual({ approved: true })
     await expect(
       gate({
-        conversationId: 'conversation-1',
+        writeGrant: grantFor('conversation-1'),
         toolName: 'vault_create_task',
         parsedArgs: { title: 'Task' }
       })
@@ -223,7 +300,7 @@ describe('AgentRuntime approval gate', () => {
 
     runtime.install()
     const pending = installedGate()({
-      conversationId: 'conversation-1',
+      writeGrant: grantFor('conversation-1'),
       toolName: 'vault_create_task',
       parsedArgs: { title: 'Task' }
     })
@@ -259,7 +336,7 @@ describe('AgentRuntime approval gate', () => {
     const gate = installedGate()
 
     const edited = gate({
-      conversationId: 'conversation-1',
+      writeGrant: grantFor('conversation-1'),
       toolName: 'vault_update_note',
       parsedArgs: { id: 'note-1', content_markdown: 'Original' }
     })
@@ -273,7 +350,7 @@ describe('AgentRuntime approval gate', () => {
     })
 
     const denied = gate({
-      conversationId: 'conversation-1',
+      writeGrant: grantFor('conversation-1'),
       toolName: 'vault_add_tag',
       parsedArgs: { id: 'note-1', tag: 'focus' }
     })
@@ -292,12 +369,12 @@ describe('AgentRuntime approval gate', () => {
     runtime.install()
     const gate = installedGate()
     const cancelled = gate({
-      conversationId: 'conversation-1',
+      writeGrant: grantFor('conversation-1'),
       toolName: 'vault_create_task',
       parsedArgs: { title: 'Task' }
     })
     const untouched = gate({
-      conversationId: 'conversation-2',
+      writeGrant: grantFor('conversation-2'),
       toolName: 'vault_create_task',
       parsedArgs: { title: 'Other task' }
     })
@@ -338,7 +415,7 @@ describe('AgentRuntime approval gate', () => {
 
     const call = createNote.handler(
       { title: 'Notes', content_markdown: 'body' },
-      { conversationId: 'conversation-1', windowId: null }
+      { writeGrant: grantFor('conversation-1'), windowId: null }
     )
     const settled = call.then(
       () => 'resolved-as-approved' as const,
@@ -361,7 +438,7 @@ describe('AgentRuntime approval gate', () => {
 
     runtime.install()
     const pending = installedGate()({
-      conversationId: 'conversation-1',
+      writeGrant: grantFor('conversation-1'),
       toolName: 'vault_create_task',
       parsedArgs: { title: 'Task' }
     })
@@ -405,7 +482,7 @@ describe('AgentRuntime approval gate', () => {
     const settled = createNote
       .handler(
         { title: 'Notes', content_markdown: 'body' },
-        { conversationId: 'conversation-1', windowId: null }
+        { writeGrant: grantFor('conversation-1'), windowId: null }
       )
       .then(
         () => 'resolved-as-approved' as const,
@@ -427,7 +504,7 @@ describe('AgentRuntime approval gate', () => {
 
     runtime.install()
     const pending = installedGate()({
-      conversationId: 'conversation-1',
+      writeGrant: grantFor('conversation-1'),
       toolName: 'vault_create_task',
       parsedArgs: { title: 'Task' }
     })
@@ -457,7 +534,7 @@ describe('AgentRuntime approval gate', () => {
     runtime.install()
     const args = { id: 'note-1', content_markdown: 'x'.repeat(64 * 1024) }
     void installedGate()({
-      conversationId: 'conversation-1',
+      writeGrant: grantFor('conversation-1'),
       toolName: 'vault_update_note',
       parsedArgs: args
     })
@@ -473,7 +550,7 @@ describe('AgentRuntime approval gate', () => {
 
     runtime.install()
     const pending = installedGate()({
-      conversationId: 'conversation-1',
+      writeGrant: grantFor('conversation-1'),
       toolName: 'vault_create_task',
       parsedArgs: { title: 'Task' }
     })

--- a/apps/desktop/src/main/agent/runtime/runtime.ts
+++ b/apps/desktop/src/main/agent/runtime/runtime.ts
@@ -4,6 +4,11 @@ import { toSafeToken } from '@memry/contracts/telemetry-api'
 import { createLogger } from '../../lib/logger'
 import { trackMainEvent } from '../../telemetry/track'
 import { setWriteGate as setMcpWriteGate } from '../mcp/lifecycle'
+import {
+  resolveTurnWriteGrant,
+  revokeAllTurnWriteGrants,
+  revokeTurnWriteGrantsFor
+} from '../turn-grants'
 import type { ConversationStore } from '../storage/conversation-store'
 import type { MessageStore } from '../storage/message-store'
 import { broadcastAgentEvent } from './event-bus'
@@ -117,7 +122,20 @@ export class AgentRuntime {
 
   install(): void {
     setMcpWriteGate(async (ctx) => {
-      const conversation = this.deps.conversations.getById(ctx.conversationId)
+      // The only thing that authorises a write. A conversation id proves
+      // nothing — it is persisted, stable and reusable — so the caller has to
+      // present the capability minted by the turn that is running right now.
+      // Anything else (an external MCP client holding the bearer token, a
+      // stale grant from a finished turn, a real conversation id) lands here.
+      const conversationId = resolveTurnWriteGrant(ctx.writeGrant)
+      if (!conversationId) {
+        return {
+          approved: false,
+          reason:
+            'Vault writes are only available to a tool call inside a running memrynote Agent turn.'
+        }
+      }
+      const conversation = this.deps.conversations.getById(conversationId)
       if (!conversation) {
         return { approved: false, reason: 'Unknown conversation' }
       }
@@ -137,7 +155,7 @@ export class AgentRuntime {
       const requiresDiff = decision.outcome === 'await_user' ? decision.requiresDiff : false
       broadcastAgentEvent({
         kind: 'tool_call_pending_approval',
-        conversationId: ctx.conversationId,
+        conversationId,
         toolCallId,
         name: ctx.toolName,
         args: ctx.parsedArgs,
@@ -152,7 +170,7 @@ export class AgentRuntime {
       })
 
       const userDecision = await this.waitForApproval({
-        conversationId: ctx.conversationId,
+        conversationId,
         toolCallId,
         name: ctx.toolName,
         args: ctx.parsedArgs,
@@ -175,7 +193,7 @@ export class AgentRuntime {
       }
 
       if (userDecision.kind === 'allow_always') {
-        this.deps.conversations.addToTrustList(ctx.conversationId, ctx.toolName)
+        this.deps.conversations.addToTrustList(conversationId, ctx.toolName)
       }
 
       const args = userDecision.kind === 'edit_allow' ? userDecision.editedArgs : ctx.parsedArgs
@@ -238,6 +256,9 @@ export class AgentRuntime {
 
   releaseTurnLock(conversationId: string): void {
     this.turnLocks.delete(conversationId)
+    // The turn is over, so its write capability dies with it. Covers the paths
+    // runTurn's own revoke cannot: a throw before it reaches its try/finally.
+    revokeTurnWriteGrantsFor(conversationId)
     // Same reasoning, from the other end: the turn is over and produced its last
     // handle before this ran, so dropping the flag here keeps the set bounded
     // rather than holding an id until that conversation is used again.
@@ -294,6 +315,7 @@ export class AgentRuntime {
   async killAll(): Promise<void> {
     this.isShuttingDown = true
     setMcpWriteGate(null)
+    revokeAllTurnWriteGrants()
 
     for (const toolCallId of [...this.pending.keys()]) {
       this.settleApproval(toolCallId, { kind: 'deny' })

--- a/apps/desktop/src/main/agent/runtime/turn.ts
+++ b/apps/desktop/src/main/agent/runtime/turn.ts
@@ -19,6 +19,7 @@ import { assemblePrompt, type PromptContext } from './prompt-assembler'
 import { COMPACTION_THRESHOLD, estimateTokens } from './token-estimator'
 import { persistToolActivity } from './tool-activity'
 import { extractAgentSourceRefs } from '../source-refs'
+import { mintTurnWriteGrant, revokeTurnWriteGrantsFor } from '../turn-grants'
 import type { AgentSourceRef } from '@memry/contracts/ipc-agent'
 
 const logger = createLogger('AgentRuntime:Turn')
@@ -162,14 +163,26 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
     trackMainError('agent', 'compact_summarize', error)
   }
 
-  const rawSub = await backend.runTurn({
-    prompt: compactedPrompt,
-    conversationId: input.conversationId,
-    windowId: input.sourceWindowId,
-    options: input.backendOptions,
-    permissions,
-    purpose: 'turn'
-  })
+  // The turn's write capability. It exists only for as long as this turn runs:
+  // every path out of the function below revokes it, and the runtime revokes it
+  // again when the turn lock is released, so a backend that outlives its turn
+  // holds a capability the gate no longer recognises.
+  const writeGrant = mintTurnWriteGrant(input.conversationId)
+  let rawSub: BackendRunHandle
+  try {
+    rawSub = await backend.runTurn({
+      prompt: compactedPrompt,
+      conversationId: input.conversationId,
+      windowId: input.sourceWindowId,
+      writeGrant,
+      options: input.backendOptions,
+      permissions,
+      purpose: 'turn'
+    })
+  } catch (error) {
+    revokeTurnWriteGrantsFor(input.conversationId)
+    throw error
+  }
   const sub = deps.trackRunHandle?.(input.conversationId, rawSub) ?? rawSub
 
   // The child is spawned and tracked, but the turn's own try/finally below has
@@ -194,6 +207,7 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
       message: assistant
     })
   } catch (error) {
+    revokeTurnWriteGrantsFor(input.conversationId)
     await discardStrandedSubprocess(sub)
     throw error
   }
@@ -326,6 +340,7 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
     // resolved (exitObserved) or the event loop above threw and abandoned a
     // child that is still running. A slow turn is still inside the loop, so it
     // is never touched here.
+    revokeTurnWriteGrantsFor(input.conversationId)
     if (!exitObserved) await killAbandonedChild(sub)
     await sub.cleanup()
     await titlePromise

--- a/apps/desktop/src/main/agent/turn-grants.ts
+++ b/apps/desktop/src/main/agent/turn-grants.ts
@@ -1,0 +1,56 @@
+import { randomBytes } from 'node:crypto'
+
+/**
+ * A capability that authorises vault writes over the Vault MCP server.
+ *
+ * The design contract is that external MCP clients are read-only and writes
+ * require an active memrynote Agent conversation. A conversation id cannot carry
+ * that contract: it is a stable, persisted identifier that survives the turn
+ * that produced it, so anything holding the server's bearer token and one id
+ * could write at any time, for as long as the vault stayed open.
+ *
+ * A grant is instead minted by the turn that is about to run, handed only to the
+ * backend that turn spawns, and revoked the moment the turn ends. Presenting one
+ * therefore proves the caller is a tool call inside a turn memrynote itself is
+ * running, which is exactly what the gate needs to know. It is 256 bits of
+ * randomness so it cannot be guessed, and it is never persisted, never sent to
+ * the renderer, and never returned by a read tool.
+ */
+declare const turnWriteGrantBrand: unique symbol
+export type TurnWriteGrant = string & { readonly [turnWriteGrantBrand]: true }
+
+/** grant -> the conversation whose in-flight turn it authorises. */
+const active = new Map<string, string>()
+
+/**
+ * Mint the grant for a turn that is starting. Any grant still held for the same
+ * conversation is dropped first: turns are serialized per conversation by the
+ * runtime's turn lock, so an older one can only be a leftover from a turn that
+ * died without reaching its revoke.
+ */
+export function mintTurnWriteGrant(conversationId: string): TurnWriteGrant {
+  revokeTurnWriteGrantsFor(conversationId)
+  const grant = randomBytes(32).toString('hex')
+  active.set(grant, conversationId)
+  return grant as TurnWriteGrant
+}
+
+/**
+ * Resolve a client-supplied header value to the conversation it authorises, or
+ * null when it names no in-flight turn. Unknown values are indistinguishable
+ * from expired ones on purpose: neither may write.
+ */
+export function resolveTurnWriteGrant(candidate: string | null | undefined): string | null {
+  if (!candidate) return null
+  return active.get(candidate) ?? null
+}
+
+export function revokeTurnWriteGrantsFor(conversationId: string): void {
+  for (const [grant, owner] of active) {
+    if (owner === conversationId) active.delete(grant)
+  }
+}
+
+export function revokeAllTurnWriteGrants(): void {
+  active.clear()
+}

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -275,13 +275,27 @@ the endpoint listening on the same URL and token. Individual client connections 
 Agent Chat and external clients can reconnect without restarting the app or reopening the vault.
 
 Client-specific config keys vary. Use the copied URL as the MCP server URL and the copied token as a
-Bearer authorization header. Plain external clients can use read tools, but they do not get the
-in-app conversation/window context that approved writes require.
+Bearer authorization header. External clients are read-only. The token admits a client to the read
+tools; it does not admit it to the write tools.
+
+Every vault write has to be authorised by a turn memrynote itself is running. When Agent Chat starts a
+turn it mints a fresh single-use write capability, hands it only to the backend it spawns for that
+turn, and destroys it when the turn ends. The write tools accept nothing else. An external client
+holding the endpoint token, or a stale capability from a turn that has already finished, is refused
+with `PERMISSION_DENIED` and the reason that writes need a running memrynote Agent turn. A conversation
+id is not a credential: knowing one, even a real one, does not let a client write.
+
+External clients still see the write tools listed. They are advertised to every client because
+memrynote's own Claude CLI, Codex CLI, and local-model backends discover their tools from that same
+list. Calling one without an active turn fails rather than writes.
 
 A write is only approved for a conversation that still exists. A conversation that has been deleted —
 including one deleted on another device and carried here by sync — no longer counts as an existing
 conversation, so its write tools are refused rather than writing into a record that is gone from your
 chat history everywhere.
+
+Closing the vault or quitting the app destroys every live write capability, so a backend that somehow
+outlives its turn cannot write afterwards.
 
 ## Tools
 
@@ -506,8 +520,9 @@ results.
 If you switch tool confirmations to **Ask first** in settings, memrynote pauses the turn and shows inline
 approval controls inside the tool row. You can allow the request once, allow create tools always for
 that conversation, deny it, or edit the arguments before allowing. Note updates load a before/after
-diff before the write is applied. Unauthenticated or context-free write requests continue to be
-denied.
+diff before the write is applied. Write requests that present no active-turn capability — every
+external MCP client, and any call arriving after its turn ended — continue to be denied, whichever
+confirmation setting you choose.
 
 Stopping the turn while an approval is waiting counts as a denial: the pending request is refused,
 the tool never runs, and the approval controls disappear. Nothing is written to your vault.


### PR DESCRIPTION
## Summary

Found while investigating an unrelated sync report. Independent of #2175; either can land first.

The Agent Chat design says external MCP clients are read-only by default and that writes require an active Memry Agent conversation plus the approval UI. The implementation did not enforce that.

The gate was installed once per vault session and cleared only at shutdown, so it was live the whole time rather than only during a turn. Its "active conversation" check was a bare existence lookup against a persisted row — it never checked that a turn was in flight, or that the caller owned the conversation. The conversation id arrived in a client-supplied `X-Memry-Conversation` header. On the shipped `always_accept` default, anything holding the endpoint bearer token plus any real conversation id could call all 47 write tools, including `vault_desktop_write`'s allowlisted renderer CRUD, with no prompt. The only thing standing in the way was that conversation ids are nanoid and no read tool exposes them — but the Claude CLI writes the token and a live conversation id into the same temp MCP config on disk for the duration of a turn.

`runTurn` now mints a 256-bit capability bound to that conversation, threads it to the backend, and destroys it on every exit path: the turn's own `finally`, the lock release covering a turn that threw first, and `killAll` at vault close. The three backends carry it as `X-Memry-Turn`. The gate resolves the presented value against the live-turn registry and takes the conversation id *from the registry*, never from the caller, so `getById` is not even reached for an unresolved grant. `AgentBackendTurnInput` carries the grant as a branded type, so calling `runTurn` without one is a compile error rather than a runtime check.

## Decisions worth a reviewer's attention

- **`tools/list` still advertises the write tools.** Filtering is cheap to implement, but the failure mode is one-sided: memrynote's own backends see the write tools only because their spawned config sets the header on every request including discovery. If any CLI stopped forwarding configured headers there, our own agent would silently lose its write tools with no error anywhere. Against that, the disclosure is near zero — the 47 names are in `apps/docs`, the caller already reads the whole vault, and a denied call now names the reason.
- **The `vault_desktop_write` allowlist is unchanged and not widened.** With writes behind a live turn, `notes.restoreVersion` and `tasks.bulkDelete` are no more reachable than `vault_delete_note` already was.
- **`toolApprovalMode` still defaults to `always_accept`,** as instructed. That is a product call and it is yours. My recommendation, for when you want it: flip to `ask` for update and delete only, not creates and not the whole surface. After this fix `always_accept` no longer means "anyone with the token can write", it means "the model memrynote is running writes without asking you" — narrower, but a prompt-injected note or web page can still steer a legitimate turn into `vault_delete_note`. The cost of flipping wholesale is that an eight-edit agent turn becomes eight interruptions, which turns a background task into a foreground one. A create-only carve-out keeps most of that flow while putting the destructive half behind a click.

One thing you may want to know: `docs/superpowers/specs/2026-05-10-agent-chat-design.md`, which root `CLAUDE.md` points at as the starting point for Agent Chat architecture, does not exist in the repo. Git history shows the whole `docs/superpowers` tree once did. I worked from the design statement in `CLAUDE.md` instead.

Memry's own backends (Claude CLI, Codex CLI, the local/OpenAI-compatible tool bridge) are unchanged from the user's point of view. A conversation persisted by an older version still opens.

## Release note

Vault writes through the local MCP server now require a running memrynote Agent turn. An external client that only knows a conversation id can no longer create, edit, or delete anything in your vault.

## Test plan

- Red first: reverting the decisive line to the pre-fix logic gives `× denies a write whose only credential is a real conversation id → expected { approved: true } to deeply equal { approved: false }`, which is the defect verbatim — a client presenting a conversation id was auto-approved. 7 tests fail.
- Green after: agent suite `Test Files 61 passed (61)` / `Tests 464 passed (464)`, including grant resolution, header extraction, a capability from an ended turn, and revocation at shutdown.
- `pnpm lint` — 0 errors (1 pre-existing warning in an untouched file)
- `pnpm typecheck` — clean
- `pnpm test` — 11/11 tasks
- `pnpm ipc:check` — up to date (no contract change, so no regenerate needed)
- `pnpm docs:impact --base origin/main --strict` and `pnpm docs:build` — pass

Not exercised against a real external MCP client end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)