### PR TITLE
fix(sync): stop a later update from downgrading a queued delete

### DIFF
--- a/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
@@ -443,6 +443,116 @@ describe('PushCoordinator', () => {
       expect(queue.getSize()).toBe(0)
       expect(markPushSynced).toHaveBeenCalledWith(expect.anything(), 'task-1')
     })
+
+    it('#then a server-side rejection of the item keeps the row instead of deleting it', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      const markPushSynced = vi.fn()
+      getHandlerMock.mockReturnValue({ markPushSynced })
+      rejectAllWith('SYNC_VALIDATION_FAILED')
+
+      const payload = JSON.stringify({ title: 'Rejected edit' })
+      queue.enqueue({ type: 'task', itemId: 'task-1', operation: 'update', payload })
+
+      await coordinator.push()
+
+      // Never deleted, never marked synced — the user's edit is still on disk.
+      expect(queue.getSize()).toBe(1)
+      expect(queue.peek()[0].payload).toBe(payload)
+      expect(markPushSynced).not.toHaveBeenCalled()
+      // One cycle costs exactly one attempt. The push loop has no backoff, so a
+      // row re-pushed inside the same call would burn the whole budget against a
+      // single burst of requests and dead-letter a transiently rejected edit for
+      // good; the row is deferred to the next cycle instead.
+      expect(postToServerMock).toHaveBeenCalledTimes(1)
+      expect(queue.peek()[0].attempts).toBe(1)
+      expect(queue.getPendingCount()).toBe(1)
+    })
+
+    it('#then the attempt budget still dead-letters the row, but only after one cycle each', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      rejectAllWith('SYNC_VALIDATION_FAILED')
+
+      queue.enqueue({
+        type: 'task',
+        itemId: 'task-1',
+        operation: 'update',
+        payload: JSON.stringify({ title: 'Doomed edit' })
+      })
+
+      for (let cycle = 1; cycle <= DEFAULT_MAX_ATTEMPTS; cycle++) {
+        await coordinator.push()
+        expect(queue.peek()[0].attempts).toBe(cycle)
+      }
+
+      // The brake is intact: the budget is spent, just spread over cycles.
+      expect(postToServerMock).toHaveBeenCalledTimes(DEFAULT_MAX_ATTEMPTS)
+      expect(queue.getPendingCount()).toBe(0)
+
+      // And a spent budget really does stop the pushing.
+      await coordinator.push()
+      expect(postToServerMock).toHaveBeenCalledTimes(DEFAULT_MAX_ATTEMPTS)
+    })
+
+    it('#then a rejected row does not block the rows queued behind it in the same cycle', async () => {
+      const { coordinator, queue, ctx } = createHarness(getDb())
+      // One row per request, so the rejected row is at the head of every dequeue.
+      ctx.options.pushBatchSize = 1
+      postToServerMock.mockImplementation(async (_path: string, body: PushBody) => {
+        const rejected = body.items.filter((i) => i.id === 'task-1')
+        return {
+          accepted: body.items.filter((i) => i.id !== 'task-1').map((i) => i.id),
+          rejected: rejected.map((i) => ({ id: i.id, reason: 'SYNC_VALIDATION_FAILED' })),
+          serverTime: Math.floor(Date.now() / 1000),
+          maxCursor: 0
+        }
+      })
+
+      queue.enqueue({
+        type: 'task',
+        itemId: 'task-1',
+        operation: 'update',
+        payload: JSON.stringify({ title: 'Rejected' })
+      })
+      queue.enqueue({
+        type: 'task',
+        itemId: 'task-2',
+        operation: 'update',
+        payload: JSON.stringify({ title: 'Fine' })
+      })
+
+      await coordinator.push()
+
+      // Two requests: the rejected row is skipped for the rest of the cycle
+      // rather than re-sent, and the healthy row behind it still goes out.
+      expect(postToServerMock).toHaveBeenCalledTimes(2)
+      expect(queue.peek()).toHaveLength(1)
+      expect(queue.peek()[0].itemId).toBe('task-1')
+      expect(queue.peek()[0].attempts).toBe(1)
+    })
+
+    it('#then a replay rejection is treated as already-synced and drops the row', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      const markPushSynced = vi.fn()
+      getHandlerMock.mockReturnValue({ markPushSynced })
+      postToServerMock.mockImplementation(async (_path: string, body: PushBody) => ({
+        accepted: [],
+        rejected: body.items.map((i) => ({ id: i.id, reason: 'SYNC_REPLAY_DETECTED' })),
+        serverTime: Math.floor(Date.now() / 1000),
+        maxCursor: 0
+      }))
+
+      queue.enqueue({
+        type: 'task',
+        itemId: 'task-1',
+        operation: 'update',
+        payload: JSON.stringify({ title: 'Already on server' })
+      })
+
+      await coordinator.push()
+
+      expect(queue.getSize()).toBe(0)
+      expect(markPushSynced).toHaveBeenCalledWith(expect.anything(), 'task-1')
+    })
   })
 
   describe('#given the edge kills an oversized push batch with 503', () => {
@@ -727,6 +837,76 @@ describe('PushCoordinator', () => {
       expect(body.items).toHaveLength(1)
       expect(body.items[0].operation).toBe('create')
       expect(JSON.parse(body.items[0].encryptedData)).toMatchObject({ title: 'second' })
+      expect(queue.getSize()).toBe(0)
+    })
+
+    // A tombstone downgraded to an update clears `deleted_at` on the server and
+    // the item comes back on every device. The delete's payload has to survive
+    // too: it carries the clock that keeps the deletion authoritative.
+    it('#then a queued delete survives a newer update row', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      acceptAll()
+      getHandlerMock.mockReturnValue({ markPushSynced: vi.fn() })
+
+      const tombstone = JSON.stringify({ id: 'cal-ev-9', clock: { 'device-1': 7 } })
+      const stale = JSON.stringify({ id: 'cal-ev-9', title: 'Retro', clock: { 'device-1': 6 } })
+      queue.enqueue({
+        type: 'calendar_external_event',
+        itemId: 'cal-ev-9',
+        operation: 'delete',
+        payload: tombstone
+      })
+      queue.markFailed(queue.peek()[0].id, 'transient')
+      queue.enqueue({
+        type: 'calendar_external_event',
+        itemId: 'cal-ev-9',
+        operation: 'update',
+        payload: stale
+      })
+      expect(queue.getSize()).toBe(2)
+
+      await coordinator.push()
+
+      const body = postToServerMock.mock.calls[0][1] as PushBody
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0].operation).toBe('delete')
+      expect(body.items[0].encryptedData).toBe(tombstone)
+      expect(queue.getSize()).toBe(0)
+    })
+
+    // The mirror case: the row exists locally again, so the last mutation is a
+    // create and the push must converge on "exists", not on the older delete.
+    it('#then a newer create row supersedes an older delete', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      acceptAll()
+      getHandlerMock.mockReturnValue({ markPushSynced: vi.fn() })
+
+      const tombstone = JSON.stringify({ id: 'cal-ev-10', clock: { 'device-1': 2 } })
+      const recreated = JSON.stringify({
+        id: 'cal-ev-10',
+        title: 'Standup',
+        clock: { 'device-1': 3 }
+      })
+      queue.enqueue({
+        type: 'calendar_external_event',
+        itemId: 'cal-ev-10',
+        operation: 'delete',
+        payload: tombstone
+      })
+      queue.markFailed(queue.peek()[0].id, 'transient')
+      queue.enqueue({
+        type: 'calendar_external_event',
+        itemId: 'cal-ev-10',
+        operation: 'create',
+        payload: recreated
+      })
+
+      await coordinator.push()
+
+      const body = postToServerMock.mock.calls[0][1] as PushBody
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0].operation).toBe('create')
+      expect(body.items[0].encryptedData).toBe(recreated)
       expect(queue.getSize()).toBe(0)
     })
   })

--- a/apps/desktop/src/main/sync/engine/push-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.ts
@@ -471,7 +471,8 @@ export class PushCoordinator {
    * `attempts = 0` row, so a failed push leaves the next edit to open a second
    * row for the same `(type, itemId)`.
    *
-   * The retained row must be the NEWEST one. `dequeue` orders
+   * The retained row must be the NEWEST one, unless the fold resolves to an
+   * older row's delete. `dequeue` orders
    * `desc(priority), asc(createdAt)`, so at equal priority the batch arrives
    * oldest-first; keeping the first row seen would keep the stale payload.
    * That only looked harmless because `resolvePushPayload` rebuilds from the
@@ -494,14 +495,15 @@ export class PushCoordinator {
         seen.set(key, item)
         continue
       }
-      // Fold the operation with the same precedence `enqueue` uses, or a
-      // create that was never acked would be downgraded to the newer row's
-      // update and pushed for an id the server has never seen.
-      seen.set(key, {
-        ...item,
-        operation: coalesceSyncOperations(older.operation, item.operation)
-      })
-      superseded.push({ id: older.id, payload: older.payload })
+      // Fold with the same precedence `enqueue` uses, or a create that was
+      // never acked would be downgraded to the newer row's update and pushed
+      // for an id the server has never seen. The fold also picks the row whose
+      // payload survives, so a tombstone keeps its own clock instead of the
+      // newer row's.
+      const folded = coalesceSyncOperations(older.operation, item.operation)
+      const [retained, dropped] = folded.payload === 'existing' ? [older, item] : [item, older]
+      seen.set(key, { ...retained, operation: folded.operation })
+      superseded.push({ id: dropped.id, payload: dropped.payload })
     }
 
     if (superseded.length > 0) {

--- a/apps/desktop/src/main/sync/queue.test.ts
+++ b/apps/desktop/src/main/sync/queue.test.ts
@@ -97,6 +97,39 @@ describe('SyncQueueManager', () => {
       expect(items[0].payload).toBe('{"deleted":true}')
     })
 
+    it('keeps the queued delete when a later update arrives', () => {
+      // #given pending delete carrying the tombstone clock
+      queue.enqueue({
+        type: 'note',
+        itemId: 'item-1',
+        operation: 'delete',
+        payload: '{"deleted":true,"clock":{"device-1":4}}'
+      })
+
+      // #when an update for the same item arrives
+      queue.enqueue(makeInput({ operation: 'update', payload: '{"v":2}' }))
+
+      // #then the tombstone survives, payload and all
+      expect(queue.getSize()).toBe(1)
+      const items = queue.peek(1)
+      expect(items[0].operation).toBe('delete')
+      expect(items[0].payload).toBe('{"deleted":true,"clock":{"device-1":4}}')
+    })
+
+    it('coalesces delete+create into create', () => {
+      // #given pending delete
+      queue.enqueue(makeInput({ operation: 'delete', payload: '{"deleted":true}' }))
+
+      // #when the item is recreated under the same id
+      queue.enqueue(makeInput({ operation: 'create', payload: '{"v":2}' }))
+
+      // #then the live item wins, with its own payload
+      expect(queue.getSize()).toBe(1)
+      const items = queue.peek(1)
+      expect(items[0].operation).toBe('create')
+      expect(items[0].payload).toBe('{"v":2}')
+    })
+
     it('coalesces update+update keeping update operation', () => {
       // #given pending update
       queue.enqueue(makeInput({ operation: 'update', payload: '{"v":1}' }))

--- a/packages/sync-client/src/queue.ts
+++ b/packages/sync-client/src/queue.ts
@@ -41,21 +41,39 @@ export interface QueueStats {
   total: number
 }
 
+export interface CoalescedMutation {
+  operation: string
+  /** Which of the two rows' payloads the folded operation must carry. */
+  payload: 'existing' | 'incoming'
+}
+
 /**
  * Fold two mutations for the same item into the single operation that has to
- * reach the server. A later delete wins outright; otherwise an unacked create
- * survives, because the server has never seen the item and an `update` for an
- * id it does not know is not the same request.
+ * reach the server, and say which payload goes with it.
+ *
+ * A delete is terminal for its id: the local row is gone, so a later `update`
+ * can only carry stale state, and folding it to `update` clears `deleted_at`
+ * server-side and resurrects the item on every device. A later `create` is the
+ * one mutation that outranks it — the row exists locally again, so the queue
+ * has to converge on "exists" rather than on the superseded tombstone.
+ * Otherwise an unacked create survives, because the server has never seen the
+ * item and an `update` for an id it does not know is not the same request.
+ *
+ * The payload side matters as much as the operation: a surviving tombstone
+ * keeps the delete's own payload, which carries the clock that makes the
+ * deletion authoritative.
  *
  * Exported because two call sites collapse rows for the same `(type, itemId)`:
  * `enqueue` (into an `attempts = 0` row) and the push coordinator's batch
  * dedupe (rows that could not coalesce because the older one had already
  * failed). They must agree, or the precedence depends on which path ran.
  */
-export function coalesceSyncOperations(existing: string, incoming: string): string {
-  if (incoming === 'delete') return 'delete'
-  if (existing === 'create' || incoming === 'create') return 'create'
-  return incoming
+export function coalesceSyncOperations(existing: string, incoming: string): CoalescedMutation {
+  if (incoming === 'delete') return { operation: 'delete', payload: 'incoming' }
+  if (incoming === 'create') return { operation: 'create', payload: 'incoming' }
+  if (existing === 'delete') return { operation: 'delete', payload: 'existing' }
+  if (existing === 'create') return { operation: 'create', payload: 'incoming' }
+  return { operation: incoming, payload: 'incoming' }
 }
 
 export class SyncQueueManager {
@@ -77,7 +95,7 @@ export class SyncQueueManager {
 
     const id = this.db.transaction((tx) => {
       const existing = tx
-        .select({ id: syncQueue.id, operation: syncQueue.operation })
+        .select({ id: syncQueue.id, operation: syncQueue.operation, payload: syncQueue.payload })
         .from(syncQueue)
         .where(
           and(eq(syncQueue.itemId, itemId), eq(syncQueue.type, type), eq(syncQueue.attempts, 0))
@@ -85,9 +103,13 @@ export class SyncQueueManager {
         .get()
 
       if (existing) {
-        const coalescedOp = coalesceSyncOperations(existing.operation, operation)
+        const folded = coalesceSyncOperations(existing.operation, operation)
         tx.update(syncQueue)
-          .set({ payload, priority, operation: coalescedOp })
+          .set({
+            payload: folded.payload === 'existing' ? existing.payload : payload,
+            priority,
+            operation: folded.operation
+          })
           .where(eq(syncQueue.id, existing.id))
           .run()
         return existing.id


### PR DESCRIPTION
## Summary

**Latent, not an active bug.** Split out of #2175 for exactly that reason, so the delete-durability work there is judged on its own evidence and this is judged on its own.

`coalesceSyncOperations` preserved `delete` only when the *incoming* operation was delete. A queued tombstone plus a later update for the same id collapsed to `update`, and `enqueue` overwrote the payload in the same statement. The push batch dedupe, `deduplicateByItemId`, applied the same precedence and kept the newer row. Either way the tombstone would be lost, and the server would then clear `deleted_at`.

Existing coverage in `queue.test.ts` had create+update, update+create, create+delete and update+update. There was no delete-then-update case, which is why this went unnoticed.

A delete is now terminal for its id within a queue generation, and the surviving row keeps the *delete's* payload, because that is what carries the deletion clock. A create still outranks a queued delete — that was already the behaviour and is now pinned by a test rather than left incidental. The fold returns which payload to keep, so both layers read the rule from one place instead of duplicating it.

## Why it is latent

I could not construct a reachable trigger on a single device. The two call sites that could arm it are each saved by a guard they do not own: `note-attachment-metadata.ts:58` and the Google calendar `sync-service.ts:98-105`. Both are one refactor away from arming it, and the consequence would be silent data loss in the direction nobody tests, which is what makes it worth closing now rather than after it bites.

If you would rather not carry the change until something actually reaches it, closing this is a reasonable call and costs #2175 nothing.

## Release note

none

## Test plan

- Failing first at both layers, identically: `AssertionError: expected 'update' to be 'delete'` at `queue.test.ts:115` and at `push-coordinator.test.ts:762`.
- Green after: `Test Files 2 passed (2)` / `Tests 69 passed (69)`, including `keeps the queued delete when a later update arrives`, `coalesces delete+create into create`, `#then a queued delete survives a newer update row`, `#then a newer create row supersedes an older delete`, and the pre-existing `#then an unacked create survives a newer update row`.
- The delete+create pair passed before and after, which is the evidence that half was already correct and is now pinned rather than changed.
- `pnpm typecheck` — 19/19 tasks.
- The two push-coordinator tests build their rows through `markFailed`, so the second row is a real `attempts > 0` sibling that `enqueue` cannot coalesce and the batch dedupe is genuinely the only thing in the way.

`MEMRY_DOCS_IMPACT_SKIP=1` on push: the change has no reachable trigger today, so there is no user-visible behaviour to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)